### PR TITLE
Add surya support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,15 +8,16 @@ Repo: [ragaeeb/swissawa](https://github.com/ragaeeb/swissawa)
 
 `swissawa` aims to support an OCR workflow for **Arabic Islamic books** in PDF form, plus the post-processing and QA steps required to produce high-quality text.
 
-This repo currently includes a baseline “PDF → page images” pipeline, plus early “crop + download” tooling:
+This repo includes a baseline “PDF → page images” pipeline, a global cropping tool, and an OCR engine:
 
-- Upload a PDF (streamed to disk for large files)
-- Extract metadata + render pages to low-res JPEGs
-- Stream progress to the browser via SSE
-- Display page previews using `next/image`
-- Set a **global crop** (draw once, applied to all previews)
-- Download the **cropped PDF** from the server
-- Cleanup cached files (delete temp dir + dedupe index)
+- **PDF Ingest**: Upload a file (streamed) or provide a URL (server-side download).
+- **Processing**: Extract metadata + render pages to low-res JPEGs using Poppler.
+- **Global Crop**: Set a `CropBox` (normalized 0..1) applied to all pages.
+- **OCR Engine**: Run `macOCR` (macOS Vision-based) on the cropped PDF.
+- **Side-by-side UI**: View scanned page images next to extracted Arabic text (optimized with `IBM Plex Sans Arabic`).
+- **Progress Tracking**: Real-time progress for both extraction and OCR via Server-Sent Events (SSE).
+- **Deduplication**: SHA-256 hashing to reuse processing artifacts for identical PDFs.
+- **Dual OCR Engines**: Supports both macOCR (macOS Vision) and Surya (ML-based) with parallel execution.
 
 ## Tech constraints / conventions
 
@@ -25,128 +26,95 @@ This repo currently includes a baseline “PDF → page images” pipeline, plus
 - **TypeScript target**: `ESNext` (see `tsconfig.json`)
 - **Formatting/Lint**: Biome (`bun run lint`, `bun run format`)
 - **API routing**: **App Router** route handlers under `src/app/api/**` (avoid `pages/api`)
+- **Typography**: Arabic text uses `IBM Plex Sans Arabic` for legibility.
 
 ## Local requirements
 
-- Poppler must be available on the machine:
-  - `pdfinfo`
-  - `pdftocairo`
+- **Poppler**: `pdfinfo`, `pdftocairo`
+- **macOCR**: CLI tool for macOS Vision-based OCR.
 
 On macOS:
 
 ```bash
 brew install poppler
+# macOCR must be in PATH
+```
+
+- **Surya OCR**: Python-based OCR with ML models. Requires virtual environment at `~/surya-env`:
+
+```bash
+python3 -m venv ~/surya-env
+source ~/surya-env/bin/activate
+pip install surya-ocr
 ```
 
 ## Key flows
 
-### Upload → extract → progress
+### Upload/URL → extract → progress
 
-1. Browser uploads PDF to `POST /api/upload` (multipart/form-data).
-2. Server streams the file to `os.tmpdir()` under `swissawa/<jobId>/input.pdf`.
+1. Browser uploads PDF to `POST /api/upload` or submits URL to `POST /api/upload-url`.
+2. Server streams/downloads the file to `os.tmpdir()` under `swissawa/<jobId>/input.pdf`.
 3. Background job:
-   - runs `pdfinfo` to collect metadata and total pages
-   - runs `pdftocairo` in **chunked + parallel** mode to generate low-res JPEG pages
-4. Browser opens `GET /api/jobs/:jobId/events` and receives:
-   - `snapshot` (initial job state)
-   - `pdf` (metadata)
-   - `progress` updates
-   - `complete` or `error`
+   - runs `pdfinfo` for metadata
+   - runs `pdftocairo` in parallel to generate JPEGs
+4. Browser opens `GET /api/jobs/:jobId/events` (SSE) for progress.
 
-### Crop → apply to previews → download
+### Crop → OCR → View
 
-- Crop is stored as a normalized `CropBox` (`x,y,width,height` in **0..1**, top-left origin).
-- UI uses `react-image-crop`; server-side download uses `pdf-lib` to set `CropBox`/`TrimBox` (and optionally `MediaBox`).
-- Download endpoint: `GET /api/jobs/:jobId/download`
-  - Default preserves original page size (avoids “looks lower quality” surprises on scanned PDFs)
-  - Optional `?shrink=1` physically shrinks pages (viewer may auto-zoom more)
-
-### Cleanup
-
-- Cleanup endpoint: `DELETE /api/jobs/:jobId`
-  - Removes `os.tmpdir()/swissawa/<jobId>/...`
-  - Removes any `os.tmpdir()/swissawa/by-hash/<sha256>.json` records pointing at that jobId
-  - Evicts in-memory job state
-
-### Image file naming gotcha (important)
-
-Poppler often writes images using **zero-padded page numbers**, e.g.:
-
-- `page-001.jpg`, `page-040.jpg`, `page-108.jpg`
-
-The resolver in `src/server/pdf/imageResolve.ts` exists specifically to prevent regressions where the server tries to serve `page-1.jpg` and returns 404s.
+1. User sets a global crop in the UI (`CropBox` 0..1).
+2. Server saves crop to `ocr/crop.json`.
+3. User runs OCR via `POST /api/jobs/:jobId/ocr` (macOCR) or `POST /api/jobs/:jobId/surya`:
+   - Server crops the PDF using `pdf-lib`.
+   - Server spawns `macOCR --language ar-SA` or `surya_ocr --disable_math`.
+   - Progress is streamed via `/ocr/events` or `/surya/events`.
+   - **Parallel execution**: Select "Both Engines" in UI to run both simultaneously.
+4. Browser fetches paged results via `/ocr/pages/:page` or `/surya/pages/:page`.
 
 ## Important paths
 
-- **UI**: `src/app/page.tsx`
+- **UI**: `src/app/page.tsx`, `src/components/PageOcrTable.tsx`
 - **API routes**:
-  - `src/app/api/upload/route.ts`
-  - `src/app/api/jobs/[jobId]/events/route.ts` (SSE)
-  - `src/app/api/jobs/[jobId]/route.ts` (status)
-  - `src/app/api/jobs/[jobId]/images/[page]/route.ts` (serve JPEG)
-  - `src/app/api/jobs/[jobId]/crop/route.ts` (get/set crop)
-  - `src/app/api/jobs/[jobId]/download/route.ts` (download original/cropped PDF)
-- **Job store**: `src/server/jobs/jobStore.ts`
-- **Temp paths**: `src/server/jobs/jobPaths.ts`
-- **Job snapshots**: `src/server/jobs/jobSnapshot.ts` (persist job state on disk for refresh/HMR)
-- **Dedupe index**: `src/server/jobs/hashIndex.ts` (sha256 → jobId)
-- **Crop persistence**: `src/server/crop/cropStore.ts`
-- **Crop PDF generation**: `src/server/pdf/cropPdf.ts`
-- **PDF parsing**: `src/server/pdf/pdfInfo.ts`
-- **PDF extraction**: `src/server/pdf/runner.ts`, `src/server/pdf/extract.ts`
-- **Image resolution**: `src/server/pdf/imageResolve.ts` (+ regression tests)
+  - `src/app/api/upload/route.ts` & `/upload-url/route.ts`
+  - `src/app/api/jobs/[jobId]/events/route.ts` (Extraction SSE)
+  - `src/app/api/jobs/[jobId]/ocr/route.ts` (Start OCR / Status)
+  - `src/app/api/jobs/[jobId]/ocr/events/route.ts` (OCR SSE)
+  - `src/app/api/jobs/[jobId]/ocr/pages/[page]/route.ts` (Get OCR text)
+  - `src/app/api/jobs/[jobId]/surya/route.ts` (Start Surya OCR / Status)
+  - `src/app/api/jobs/[jobId]/surya/events/route.ts` (Surya SSE)
+  - `src/app/api/jobs/[jobId]/surya/pages/[page]/route.ts` (Get Surya text)
+- **OCR Logic**: `src/server/ocr/runMacOcr.ts`, `src/server/ocr/runSuryaOcr.ts`, `src/server/ocr/ocrEventBus.ts`
+- **Job store**: `src/server/jobs/jobStore.ts` (in-memory + filesystem fallback)
 
-## Tests
+## Lessons learned / common pitfalls (CRITICAL)
 
-Run:
+- **Next.js HMR resets module state**: In development, `globalThis` MUST be used to store event buses or singleton stores that need to persist across reloads (see `ocrEventBus.ts`).
+- **CLI Output Buffering**: Many CLI tools (like `macOCR`) buffer stdout when piped. Use `script -q /dev/null <cmd>` on macOS to force line-buffering so SSE can show real-time progress.
+- **Arabic Typography**: Standard fonts like "Amiri" are hard to read in digital tables. `IBM Plex Sans Arabic` is currently preferred. Always use `dir="rtl"` and `text-right` for Arabic content.
+- **SSE Missed Events**: If a process finishes before the SSE client connects, the client might hang. Always check current status immediately upon SSE connection and send a terminal event if already finished.
+- **Race Conditions in React**: When fetching paged data (like OCR text per row), use `AbortController` in `useEffect` to prevent setting state for a job/page that is no longer active.
+- **Build Safety with SearchParams**: Using `useSearchParams()` at the root level of a page causes Next.js to bail out of static rendering. Use manual `window.location` parsing or wrap in `<Suspense>` to keep the build safe.
+- **Surya Virtual Environment**: Surya runs in a Python venv at `~/surya-env`. The runner activates it via `bash -c "source ... && surya_ocr ..."`.
+- **GPU Fallback**: Surya prefers MPS (Metal) on macOS but falls back to CPU if MPS fails. Set `TORCH_DEVICE` environment variable accordingly.
+- **Large JSON Filtering**: Surya outputs massive results.json with character-level data. Filter using `filterSuryaRawOutput()` to strip `chars`, `confidence`, `polygon`, `words` before storage.
+- **Surya Page Indexing**: Surya's `results.json` uses **1-indexed** pages (`"page": 1` for first page). Do NOT add +1 when converting to ObservationPage format - they're already 1-indexed.
+- **AbortError in React**: When fetching data in `useEffect`, wrap fetch in try-catch and silently return `null` for AbortError. Otherwise component unmounts spam the console with errors.
+- **Progress UI Priority**: When showing progress, prioritize the raw `line` field (contains actual percentages like "25%|████") over generic `phase` labels. Users want to see real progress, not just "Recognizing text…".
+- **Dual SSE Connections**: When running both OCR engines, each engine has its own SSE endpoint. Use separate `EventSource` refs and ensure cleanup in `useEffect` return function.
 
-```bash
-bun test
-```
+## Debugging tips for future agents
 
-Guideline:
-- Add unit tests for any parsing/formatting/path logic and for bug regressions (e.g., padding logic, directory inference).
-- Avoid component tests for now (no React Testing Library yet).
-- **Test style**: prefer `it('should ...')` (over `test(...)`) for consistency across the repo.
-
-## Lessons learned / common pitfalls (read this first)
-
-- **Poppler filename padding**: Poppler often writes `page-001.jpg`. Always resolve images via `src/server/pdf/imageResolve.ts` to avoid 404s after extraction.
-- **Dev refresh/HMR resets memory**: The in-memory job store can disappear; always keep filesystem fallbacks (job snapshot + image resolver).
-- **Deduplication needs cleanup**: If you delete a job dir but leave its `by-hash` record, future uploads will “reuse” a dead jobId. Cleanup must remove both.
-- **react-image-crop callback gotcha**: `onComplete(pixelCrop, percentCrop)`—using the wrong arg causes crop “jumping” on mouse-up.
-- **Crop units mismatch**: UI percent crop is **0..100**, server crop box is **0..1**. Conversions live in `src/lib/cropConvert.ts`.
-- **Thumbnails vs crop**: `object-cover` will “pre-crop” before `clip-path`. Use `object-contain` if you want the crop to visually match saved values.
-- **Cropped PDF “quality”**: Shrinking `MediaBox` makes viewers auto-zoom more; default download preserves page size and uses `TrimBox`/`CropBox`.
-
-## Latest achievements (so you know what’s already done)
-
-- **Upload + SSE progress** (App Router) with Poppler extraction (chunked + parallel).
-- **Persistent resume** via job snapshots on disk + hash-based dedupe.
-- **Global crop UI** using `react-image-crop` + server storage.
-- **Download cropped PDF** via `pdf-lib` (+ caching; optional `?shrink=1`).
-- **Cleanup endpoint + UI** to delete cached files and dedupe records.
+- **Check surya output location**: Surya outputs to `<outputDir>/input/results.json` (where `input` is derived from `input.pdf` basename). Not directly in `<outputDir>`.
+- **Verify page JSON files**: If pages show "Loading..." after OCR completes, check that `surya/pages/1.json` exists. If it's missing but `2.json` exists, there's an indexing bug.
+- **Test with real results.json**: Copy actual Surya output (`results.json`) to project root and inspect the `page` field values directly - don't assume they're 0-indexed.
+- **SSE debugging**: Add console.info in `createEventSource` to see connection/disconnect events. Check for `[jobs.surya.sse.connect]` logs on the server.
+- **CPU spinning after completion**: If observed, check that child processes are properly terminated. The `spawn` mock in tests should verify cleanup.
 
 ## Performance notes
 
-Arabic books can be thousands of pages.
-
-- Prefer **paged / progressive UI** (don’t return an array of 10k URLs in one JSON response).
-- In the backend, keep extraction chunked and parallelized (CPU-bound; concurrency should be tied to CPU count).
-- Keep images low-res/low-quality by default; allow later tuning.
-
-## Safety / future hardening
-
-This code currently stores uploads under `os.tmpdir()` and keeps job state in-memory for simplicity.
-Before productionizing:
-
-- Add job persistence and cleanup (TTL) for tmp dirs
-- Add upload limits, auth, and CSRF protections as needed
-- Consider queueing / rate-limiting / per-job concurrency caps
-- Validate PDFs more robustly (malformed PDFs, encrypted PDFs)
+- **Chunked Extraction**: Extraction is parallelized based on CPU count.
+- **Paged OCR results**: OCR JSON can be massive (MBs of data). Never send the full JSON in one request; use the paged API (`/ocr/pages/:page`).
+- **Disk Persistence**: Always write a `snapshot.json` to the job directory. This allows the server to recover job state if the Node process restarts.
 
 ## License
 
 MIT — see `LICENSE.md`.
-
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,14 @@ pip install surya-ocr
 - **Verify page JSON files**: If pages show "Loading..." after OCR completes, check that `surya/pages/1.json` exists. If it's missing but `2.json` exists, there's an indexing bug.
 - **Test with real results.json**: Copy actual Surya output (`results.json`) to project root and inspect the `page` field values directly - don't assume they're 0-indexed.
 - **SSE debugging**: Add console.info in `createEventSource` to see connection/disconnect events. Check for `[jobs.surya.sse.connect]` logs on the server.
-- **CPU spinning after completion**: If observed, check that child processes are properly terminated. The `spawn` mock in tests should verify cleanup.
+- **CPU spinning after completion**: If observed, check the `stderr` parsing logic in `runSuryaOcr.ts`. Ensure that we are not accumulating infinite strings in memory and that the stream listeners are cleaned up. Using `child.unref()` might be necessary if the server needs to exit while the process runs, but here we prefer keeping them attached for logging.
+- **Parallel Fetching**: The `PageOcrTable` fetches text for multiple pages in parallel when "Both Engines" is selected. This can hit rate limits or cause saturation; ensure the `useEffect` fetch loop is serial per-engine to keep the network tab manageable.
+
+## Process Management & CPU Usage
+
+- **Surya Resource Usage**: Surya is heavy. It can consume significant RAM/GPU. If it hangs, use `ps aux | grep surya` to find orphaned python processes.
+- **Signal Handling**: The browser's `AbortController` only aborts the *network request*. It does NOT stop the server-side OCR process. To stop the OCR, a separate `DELETE` or `POST /cancel` endpoint would be needed (currently not implemented).
+- **Stream Throttling**: The SSE progress events are emitted for every line of `stderr`. If Surya outputs thousands of lines rapidly, it might bog down the React main thread. The current implementation relies on the browser/server TCP windowing, but consider adding a debounce if UI lag occurs.
 
 ## Performance notes
 

--- a/README.md
+++ b/README.md
@@ -23,15 +23,25 @@
 ### Requirements
 
 - **Bun**: `>=1.3.5`
-- **Node.js**: `>=24` (used by Next.js tooling; Bun is the package manager)
-- **Poppler** (for fast PDF metadata + page rendering):
-  - `pdfinfo`
-  - `pdftocairo`
+- **Node.js**: `>=24`
+- **Poppler** (PDF rendering): `pdfinfo`, `pdftocairo`
+- **macOCR** (Arabic OCR): macOS Vision-based CLI tool
+- **Surya OCR** (optional): ML-based OCR with GPU acceleration
 
 On macOS:
 
 ```bash
 brew install poppler
+```
+
+### Optional: Surya OCR Setup
+
+For ML-based OCR with GPU (MPS) acceleration:
+
+```bash
+python3 -m venv ~/surya-env
+source ~/surya-env/bin/activate
+pip install surya-ocr
 ```
 
 ### Run dev server
@@ -48,80 +58,52 @@ Open `http://localhost:3000`.
 bun test
 ```
 
-### Formatting / linting
+## Current functionality
 
-```bash
-bun run lint
-bun run format
-```
-
-## Current functionality (baseline)
-
-- **Drag & drop PDF upload** (streams to disk to support large PDFs)
-- **Server-side PDF → low-res JPEG pages** using Poppler (`pdftocairo`)
-- **Progress updates via SSE**
-- **Image serving via API routes**, displayed using `next/image` for optimized rendering
-- **Global crop**: draw a crop on one page and apply to all previews
-- **Download cropped PDF** (server-generated; preserves page size by default)
-- **Cleanup cached files** (delete uploaded PDF + extracted images)
-- **Deduplication**: reuse extracted images across re-uploads via SHA-256 content hashing
-
-Temporary files are written under `os.tmpdir()` (e.g. `.../T/swissawa/<jobId>/...` on macOS).
+- **Flexible PDF Ingest**: Upload via drag & drop or provide a remote URL for server-side download.
+- **Fast Page Extraction**: Parallelized PDF-to-JPEG rendering using Poppler.
+- **Global Cropping**: Define a crop box once and apply it to the entire book.
+- **Dual OCR Engines**: Choose between macOCR (Vision), Surya (ML), or run both in parallel.
+- **Engine Selection UI**: Dropdown to select "Both Engines", "macOCR Only", or "Surya Only".
+- **GPU Acceleration**: Surya uses MPS (Metal) on M-series Macs with automatic CPU fallback.
+- **Side-by-Side Comparison**: When running both engines, results appear in adjacent columns for comparison.
+- **Real-time Feedback**: SSE-powered progress bars showing actual percentages for each engine.
+- **Deduplication**: SHA-256 hashing avoids re-processing identical files.
+- **Arabic-First UI**: Optimized typography using `IBM Plex Sans Arabic` and RTL-aware layout.
 
 ## API (App Router)
 
-- `POST /api/upload`: upload a PDF (multipart/form-data), returns `{ jobId, sha256, reused }`
-- `GET /api/jobs/:jobId/events`: SSE stream (`snapshot`, `pdf`, `progress`, `complete`, `error`)
-- `GET /api/jobs/:jobId`: job status; optional paging via `?from=&to=`
-- `DELETE /api/jobs/:jobId`: delete cached files for a job (temp dir + hash index) and evict in-memory state
-- `GET /api/jobs/:jobId/images/:page`: serve a rendered JPEG page
-- `GET /api/jobs/:jobId/crop`: get the saved crop (or `null`)
-- `POST /api/jobs/:jobId/crop`: set the saved crop (`{ crop: { x,y,width,height } }`, normalized 0..1)
-- `GET /api/jobs/:jobId/download`: download the original PDF if no crop, otherwise a cropped PDF
-  - Optional: `?shrink=1` to physically shrink pages (can make scanned PDFs look “lower quality” due to extra zoom)
+### Ingest & Jobs
+- `POST /api/upload`: Upload PDF (multipart).
+- `POST /api/upload-url`: Provide a PDF URL to fetch.
+- `GET /api/jobs/:jobId`: Job status and metadata.
+- `GET /api/jobs/:jobId/events`: Extraction progress (SSE).
+- `DELETE /api/jobs/:jobId`: Cleanup all files and state.
 
-## Notes
+### Images & Crop
+- `GET /api/jobs/:jobId/images/:page`: Serve rendered JPEG.
+- `POST /api/jobs/:jobId/crop`: Save global crop.
+- `GET /api/jobs/:jobId/download`: Download cropped PDF.
 
-- **Upload size limit**: controlled by `SWISSAWA_MAX_UPLOAD_BYTES` (defaults to 64MB).
+### OCR (macOCR)
+- `POST /api/jobs/:jobId/ocr`: Trigger `macOCR` process.
+- `GET /api/jobs/:jobId/ocr`: Check OCR status.
+- `GET /api/jobs/:jobId/ocr/events`: OCR progress stream (SSE).
+- `GET /api/jobs/:jobId/ocr/pages/:page`: Fetch extracted text for a specific page.
 
-## Project goal / roadmap (high-level)
+### OCR (Surya)
+- `POST /api/jobs/:jobId/surya`: Trigger Surya OCR process.
+- `GET /api/jobs/:jobId/surya`: Check Surya status.
+- `GET /api/jobs/:jobId/surya/events`: Surya progress stream (SSE).
+- `GET /api/jobs/:jobId/surya/pages/:page`: Fetch Surya text for a specific page.
 
-The long-term intent is to support:
+## Roadmap
 
-- Arabic OCR workflows (layout-aware, RTL-friendly)
-- Post-processing (normalization, diacritics handling, tokenization, line/paragraph reconstruction)
-- QA tooling (diffs against ground truth, confidence heatmaps, error review queues)
+- Layout-aware OCR (preserving columns/paragraphs).
+- Text post-processing (normalization, diacritics).
+- QA/diffing tools for ground truth verification.
 
-See `AGENTS.md` for a guided architecture map, pitfalls, and development conventions.
-
-## Future ideas (serverless-ready architecture)
-
-Today’s baseline implementation is optimized for local/dev and a traditional server:
-
-- Uses **Poppler** binaries (`pdfinfo`, `pdftocairo`)
-- Writes to `os.tmpdir()`
-- Uses an in-memory job store
-- Streams progress via **SSE**
-
-This is not a great fit for pure serverless platforms (e.g. Vercel/Netlify) due to ephemeral disk, cold starts/scale-out, execution time limits, and long-lived connections.
-
-Some options to make this serverless-friendly:
-
-- **Direct-to-storage upload + external worker (recommended)**:
-  - Use [UploadThing](https://uploadthing.com/) for browser → storage uploads (your server only authenticates/authorizes)
-  - Trigger background processing via a worker/queue (e.g. Trigger.dev) to:
-    - download the PDF
-    - render page images
-    - write progress + outputs to durable storage (S3/R2/UploadThing/etc.)
-  - Frontend reads progress from a DB/KV (polling or SSE that only reads state)
-
-- **Pure JS/WASM rendering in serverless**:
-  - Replace Poppler with a PDF renderer that runs without native binaries (often pdf.js-based)
-  - Still requires durable storage for the PDF + images and persistent job state
-
-- **Hybrid hosting**:
-  - Keep the Next.js web app on Vercel/Netlify, but run the extraction/OCR worker on a container VM (Fly.io/Render/Railway)
-  - Keep progress + artifacts in a DB/object storage so the UI remains stateless
+See `AGENTS.md` for deep-dive architecture notes and development pitfalls.
 
 ## License
 
@@ -129,4 +111,4 @@ MIT — see [`LICENSE.md`](LICENSE.md).
 
 # Inspiration
 
-The name of the project comes from Suhayla: a food that is both sweet and sour at the same time.
+The name comes from Suhayla: a food that is both sweet and sour at the same time.

--- a/src/app/api/jobs/[jobId]/surya/events/route.ts
+++ b/src/app/api/jobs/[jobId]/surya/events/route.ts
@@ -1,0 +1,95 @@
+import { readJobSnapshot } from '@/server/jobs/jobSnapshot';
+import { globalJobStore } from '@/server/jobs/jobStore';
+import { getLastSuryaProgress, suryaBus } from '@/server/ocr/ocrEventBus';
+import { formatSseEvent } from '@/server/sse/sse';
+
+export const runtime = 'nodejs';
+
+export async function GET(_request: Request, { params }: { params: Promise<{ jobId: string }> }): Promise<Response> {
+    const { jobId } = await params;
+    console.info('[jobs.surya.sse.connect]', { jobId });
+
+    const job = globalJobStore.get(jobId) ?? (await readJobSnapshot(jobId));
+    if (!job) {
+        console.warn('[jobs.surya.sse.not_found]', { jobId });
+        return Response.json({ error: 'Job not found' }, { status: 404 });
+    }
+
+    const bus = suryaBus(jobId);
+    const encoder = new TextEncoder();
+
+    let heartbeat: ReturnType<typeof setInterval> | null = null;
+    let cleanup: (() => void) | null = null;
+
+    const stream = new ReadableStream<Uint8Array>({
+        cancel() {
+            console.info('[jobs.surya.sse.cancel]', { jobId });
+            cleanup?.();
+        },
+        start(controller) {
+            const write = (s: string) => controller.enqueue(encoder.encode(s));
+
+            const closeStream = () => {
+                cleanup?.();
+                controller.close();
+            };
+
+            const status = job.suryaOcr?.status ?? 'idle';
+            write(formatSseEvent('snapshot', { progress: getLastSuryaProgress(jobId), status }));
+
+            // If OCR is already done (or errored) by the time the client connects, emit terminal event immediately.
+            if (status === 'complete') {
+                console.info('[jobs.surya.sse.complete]', { immediate: true, jobId });
+                write(formatSseEvent('complete', { status: 'complete' }));
+                closeStream();
+                return;
+            }
+            if (status === 'error') {
+                const message = job.suryaOcr?.error ?? 'Surya OCR failed';
+                console.error('[jobs.surya.sse.error]', { immediate: true, jobId, message });
+                write(formatSseEvent('error', { message }));
+                closeStream();
+                return;
+            }
+
+            const onProgress = (ev: unknown) => write(formatSseEvent('progress', ev));
+            const onComplete = () => {
+                console.info('[jobs.surya.sse.complete]', { jobId });
+                write(formatSseEvent('complete', { status: 'complete' }));
+                closeStream();
+            };
+            const onError = (message: string) => {
+                console.error('[jobs.surya.sse.error]', { jobId, message });
+                write(formatSseEvent('error', { message }));
+                closeStream();
+            };
+
+            bus.on('progress', onProgress as any);
+            bus.on('complete', onComplete);
+            bus.on('error', onError);
+
+            heartbeat = setInterval(() => {
+                write(':\n\n');
+            }, 15_000);
+
+            cleanup = () => {
+                if (heartbeat) {
+                    clearInterval(heartbeat);
+                    heartbeat = null;
+                }
+                bus.off('progress', onProgress as any);
+                bus.off('complete', onComplete);
+                bus.off('error', onError);
+            };
+        },
+    });
+
+    return new Response(stream, {
+        headers: {
+            'Cache-Control': 'no-cache, no-transform',
+            Connection: 'keep-alive',
+            'Content-Type': 'text/event-stream; charset=utf-8',
+            'X-Accel-Buffering': 'no',
+        },
+    });
+}

--- a/src/app/api/jobs/[jobId]/surya/pages/[page]/route.ts
+++ b/src/app/api/jobs/[jobId]/surya/pages/[page]/route.ts
@@ -1,0 +1,48 @@
+import { createReadStream } from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { readJobSnapshot } from '@/server/jobs/jobSnapshot';
+import { globalJobStore } from '@/server/jobs/jobStore';
+import { jobSuryaPagesDir } from '@/server/ocr/ocrPaths';
+
+export const runtime = 'nodejs';
+
+function parsePageParam(v: string): number | null {
+    const n = Number.parseInt(v, 10);
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+        return null;
+    }
+    return n;
+}
+
+export async function GET(
+    _request: Request,
+    ctx: { params: Promise<{ jobId: string; page: string }> },
+): Promise<Response> {
+    const { jobId, page } = await ctx.params;
+
+    const job = globalJobStore.get(jobId) ?? (await readJobSnapshot(jobId));
+    if (!job) {
+        return Response.json({ error: 'Job not found' }, { status: 404 });
+    }
+
+    const pageNumber = parsePageParam(page);
+    if (!pageNumber) {
+        return Response.json({ error: 'Invalid page' }, { status: 400 });
+    }
+
+    const filePath = path.join(jobSuryaPagesDir(jobId), `${pageNumber}.json`);
+    try {
+        await fsp.stat(filePath);
+        const stream = createReadStream(filePath);
+        return new Response(Readable.toWeb(stream) as any, {
+            headers: {
+                'Cache-Control': job.suryaOcr?.status === 'complete' ? 'public, max-age=3600, immutable' : 'no-store',
+                'Content-Type': 'application/json; charset=utf-8',
+            },
+        });
+    } catch {
+        return Response.json({ error: 'Surya OCR page not found' }, { status: 404 });
+    }
+}

--- a/src/app/api/jobs/[jobId]/surya/route.ts
+++ b/src/app/api/jobs/[jobId]/surya/route.ts
@@ -1,0 +1,94 @@
+import * as fsp from 'node:fs/promises';
+import { readJobSnapshot } from '@/server/jobs/jobSnapshot';
+import { globalJobStore } from '@/server/jobs/jobStore';
+import { jobSuryaMetaPath, jobSuryaOcrJsonPath, jobSuryaPagesDir } from '@/server/ocr/ocrPaths';
+import { runSuryaOcr } from '@/server/ocr/runSuryaOcr';
+
+export const runtime = 'nodejs';
+
+async function exists(p: string): Promise<boolean> {
+    try {
+        await fsp.stat(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function ensureJobInStore(jobId: string): Promise<void> {
+    if (globalJobStore.get(jobId)) {
+        return;
+    }
+    const snap = await readJobSnapshot(jobId);
+    if (!snap) {
+        return;
+    }
+    globalJobStore.create({
+        crop: snap.crop,
+        error: snap.error,
+        id: snap.id,
+        info: snap.info,
+        ocr: snap.ocr,
+        outputDir: snap.outputDir,
+        pdfPath: snap.pdfPath,
+        progress: snap.progress,
+        sourceUrl: snap.sourceUrl,
+        status: snap.status,
+        suryaOcr: snap.suryaOcr,
+    });
+}
+
+export async function POST(_request: Request, ctx: { params: Promise<{ jobId: string }> }): Promise<Response> {
+    const { jobId } = await ctx.params;
+    console.info('[jobs.surya.post]', { jobId });
+    await ensureJobInStore(jobId);
+    if (!globalJobStore.get(jobId)) {
+        console.warn('[jobs.surya.post.not_found]', { jobId });
+        return Response.json({ error: 'Job not found' }, { status: 404 });
+    }
+
+    const job = globalJobStore.get(jobId)!;
+    if (job.suryaOcr?.status === 'running') {
+        console.info('[jobs.surya.post.already_running]', { jobId });
+        return Response.json({ status: 'running' });
+    }
+    if (job.suryaOcr?.status === 'complete') {
+        console.info('[jobs.surya.post.already_complete]', { jobId });
+        return Response.json({ status: 'complete' });
+    }
+
+    // Fire-and-forget: Surya OCR can take a long time; the UI should poll GET /surya for status.
+    console.info('[jobs.surya.start]', { jobId });
+    void runSuryaOcr({ jobId, store: globalJobStore }).catch((err: unknown) => {
+        console.error('[jobs.surya]', { jobId, message: err instanceof Error ? err.message : String(err) });
+    });
+    return Response.json({ status: 'running' });
+}
+
+export async function GET(_request: Request, ctx: { params: Promise<{ jobId: string }> }): Promise<Response> {
+    const { jobId } = await ctx.params;
+    const job = globalJobStore.get(jobId) ?? (await readJobSnapshot(jobId));
+    if (!job) {
+        return Response.json({ error: 'Job not found' }, { status: 404 });
+    }
+
+    const status = job.suryaOcr?.status ?? 'idle';
+    const error = job.suryaOcr?.status === 'error' ? (job.suryaOcr?.error ?? 'Surya OCR failed') : undefined;
+    const metaRaw = await fsp.readFile(jobSuryaMetaPath(jobId), 'utf8').catch(() => null);
+    const meta = metaRaw ? (JSON.parse(metaRaw) as unknown) : null;
+
+    if (status !== 'complete') {
+        return Response.json({ error, meta, status });
+    }
+
+    const hasPagesSplit = await exists(jobSuryaPagesDir(jobId));
+    const pagesBaseUrl = `/api/jobs/${encodeURIComponent(jobId)}/surya/pages`;
+    const totalPages =
+        typeof (meta as any)?.totalPages === 'number' ? ((meta as any).totalPages as number) : job.progress.totalPages;
+
+    return Response.json({
+        delivery: { kind: hasPagesSplit ? 'pages' : 'file', pagesBaseUrl, totalPages },
+        meta,
+        status,
+    });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Image from 'next/image';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { CropDialog } from '@/components/CropDialog';
 import { PageOcrTable } from '@/components/PageOcrTable';

--- a/src/components/PageOcrTable.tsx
+++ b/src/components/PageOcrTable.tsx
@@ -9,29 +9,28 @@ import type { CropBox } from '@/server/crop/crop';
 import { cropBoxToClipPathInset } from '@/server/crop/crop';
 
 type OcrStatus = 'idle' | 'running' | 'complete' | 'error';
+type OcrEngine = 'macOCR' | 'surya' | 'both';
 
-type OcrProgress = { line: string; currentPage?: number; totalPages?: number };
+type OcrProgress = { line: string; currentPage?: number; totalPages?: number; phase?: string };
 
 function isProbablyRtl(text: string): boolean {
-    // Arabic + Arabic Supplement + Arabic Extended-A + Arabic Presentation Forms + Hebrew
     return /[\u0590-\u05FF\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/.test(text);
 }
 
 type OcrStatusResponse = { status: OcrStatus; error?: string };
 
 function scheduleOcrStatusSyncs(params: {
-    jobId: string;
+    endpoint: string;
     setOcrError: (v: string | null) => void;
     setOcrReady: (v: boolean) => void;
     setOcrStatus: (v: OcrStatus) => void;
 }) {
-    // Bounded fallback: if SSE is blocked or misses the terminal event, sync status a few times.
     const delays = [500, 1500, 3000];
     for (const d of delays) {
         window.setTimeout(() => {
             void (async () => {
                 try {
-                    const r = await fetch(`/api/jobs/${encodeURIComponent(params.jobId)}/ocr`);
+                    const r = await fetch(params.endpoint);
                     if (!r.ok) {
                         return;
                     }
@@ -44,38 +43,87 @@ function scheduleOcrStatusSyncs(params: {
                         params.setOcrError(data.error ?? 'OCR error');
                     }
                 } catch {
-                    // ignore
+                    /* ignore */
                 }
             })();
         }, d);
     }
 }
 
-async function fetchOcrTextForPage(jobId: string, pageNumber: number, signal: AbortSignal): Promise<string | null> {
-    const res = await fetch(`/api/jobs/${encodeURIComponent(jobId)}/ocr/pages/${pageNumber}`, { signal });
-    if (!res.ok) {
+async function fetchOcrTextForPage(
+    jobId: string,
+    pageNumber: number,
+    engine: 'ocr' | 'surya',
+    signal: AbortSignal,
+): Promise<string | null> {
+    try {
+        const res = await fetch(`/api/jobs/${encodeURIComponent(jobId)}/${engine}/pages/${pageNumber}`, { signal });
+        if (!res.ok) {
+            return null;
+        }
+        const page = (await res.json()) as ObservationPage;
+        return page.observations.map((o) => o.text).join('\n');
+    } catch (err: unknown) {
+        // AbortError is expected when component unmounts or job changes
+        if (err instanceof Error && err.name === 'AbortError') {
+            return null;
+        }
+        console.warn('[fetchOcrTextForPage.error]', { engine, err, jobId, pageNumber });
         return null;
     }
-    const page = (await res.json()) as ObservationPage;
-    return page.observations.map((o) => o.text).join('\n');
+}
+
+function OcrTextCell({
+    ready,
+    text,
+    extractedPages,
+    pageNumber,
+}: {
+    ready: boolean;
+    text?: string;
+    extractedPages: number;
+    pageNumber: number;
+}) {
+    if (!ready) {
+        return <div className="text-xs text-zinc-600 dark:text-zinc-400">Run OCR to populate text.</div>;
+    }
+    return (
+        <div
+            dir={text && isProbablyRtl(text) ? 'rtl' : 'ltr'}
+            className={[
+                'whitespace-pre-wrap font-arabic text-[17px] leading-[1.8]',
+                text && isProbablyRtl(text) ? 'text-right' : 'text-left',
+            ].join(' ')}
+        >
+            {text ?? (pageNumber <= extractedPages ? 'Loading…' : '')}
+        </div>
+    );
 }
 
 function PageRow({
     clipPath,
     extractedPages,
     jobId,
-    ocrReady,
-    ocrText,
+    macOcrReady,
+    macOcrText,
+    suryaReady,
+    suryaText,
     onCropPage,
     pageNumber,
+    showMacOcr,
+    showSurya,
 }: {
     pageNumber: number;
     jobId: string;
     extractedPages: number;
     onCropPage: (pageNumber: number) => void;
     clipPath?: string;
-    ocrReady: boolean;
-    ocrText?: string;
+    macOcrReady: boolean;
+    macOcrText?: string;
+    suryaReady: boolean;
+    suryaText?: string;
+    showMacOcr: boolean;
+    showSurya: boolean;
 }) {
     return (
         <TableRow>
@@ -107,21 +155,26 @@ function PageRow({
                     )}
                 </div>
             </TableCell>
-            <TableCell className="align-top">
-                {ocrReady ? (
-                    <div
-                        dir={ocrText && isProbablyRtl(ocrText) ? 'rtl' : 'ltr'}
-                        className={[
-                            'whitespace-pre-wrap font-arabic text-[17px] leading-[1.8]',
-                            ocrText && isProbablyRtl(ocrText) ? 'text-right' : 'text-left',
-                        ].join(' ')}
-                    >
-                        {ocrText ?? (pageNumber <= extractedPages ? 'Loading…' : '')}
-                    </div>
-                ) : (
-                    <div className="text-xs text-zinc-600 dark:text-zinc-400">Run OCR to populate text.</div>
-                )}
-            </TableCell>
+            {showMacOcr && (
+                <TableCell className="align-top">
+                    <OcrTextCell
+                        ready={macOcrReady}
+                        text={macOcrText}
+                        extractedPages={extractedPages}
+                        pageNumber={pageNumber}
+                    />
+                </TableCell>
+            )}
+            {showSurya && (
+                <TableCell className="align-top">
+                    <OcrTextCell
+                        ready={suryaReady}
+                        text={suryaText}
+                        extractedPages={extractedPages}
+                        pageNumber={pageNumber}
+                    />
+                </TableCell>
+            )}
         </TableRow>
     );
 }
@@ -146,146 +199,249 @@ export function PageOcrTable({
     onCropPage: (pageNumber: number) => void;
 }) {
     const clipPath = useMemo(() => (crop ? cropBoxToClipPathInset(crop) : undefined), [crop]);
-    const [ocrStatus, setOcrStatus] = useState<OcrStatus>('idle');
-    const [ocrError, setOcrError] = useState<string | null>(null);
-    const [ocrProgress, setOcrProgress] = useState<OcrProgress | null>(null);
-    const [ocrReady, setOcrReady] = useState(false);
-    const [ocrTextByPage, setOcrTextByPage] = useState<Record<number, string>>({});
+    const [selectedEngine, setSelectedEngine] = useState<OcrEngine>('both');
 
-    const esRef = useRef<EventSource | null>(null);
+    // macOCR state
+    const [macOcrStatus, setMacOcrStatus] = useState<OcrStatus>('idle');
+    const [macOcrError, setMacOcrError] = useState<string | null>(null);
+    const [macOcrProgress, setMacOcrProgress] = useState<OcrProgress | null>(null);
+    const [macOcrReady, setMacOcrReady] = useState(false);
+    const [macOcrTextByPage, setMacOcrTextByPage] = useState<Record<number, string>>({});
+    const macOcrEsRef = useRef<EventSource | null>(null);
 
-    const ensureOcrEventSource = useCallback((): void => {
-        if (esRef.current) {
-            return;
-        }
-        console.info('[ocr.sse.client.connect]', { jobId });
-        const es = new EventSource(`/api/jobs/${encodeURIComponent(jobId)}/ocr/events`);
-        esRef.current = es;
+    // Surya state
+    const [suryaStatus, setSuryaStatus] = useState<OcrStatus>('idle');
+    const [suryaError, setSuryaError] = useState<string | null>(null);
+    const [suryaProgress, setSuryaProgress] = useState<OcrProgress | null>(null);
+    const [suryaReady, setSuryaReady] = useState(false);
+    const [suryaTextByPage, setSuryaTextByPage] = useState<Record<number, string>>({});
+    const suryaEsRef = useRef<EventSource | null>(null);
 
-        es.addEventListener('open', () => {
-            console.info('[ocr.sse.client.open]', { jobId });
-        });
+    const showMacOcr = selectedEngine === 'macOCR' || selectedEngine === 'both';
+    const showSurya = selectedEngine === 'surya' || selectedEngine === 'both';
 
-        es.addEventListener('snapshot', (ev) => {
-            const data = JSON.parse((ev as MessageEvent).data) as { status: OcrStatus; progress?: OcrProgress | null };
-            setOcrStatus(data.status);
-            setOcrProgress(data.progress ?? null);
-            setOcrReady(data.status === 'complete');
-        });
-
-        es.addEventListener('progress', (ev) => {
-            const data = JSON.parse((ev as MessageEvent).data) as OcrProgress;
-            setOcrProgress(data);
-            setOcrStatus('running');
-        });
-
-        es.addEventListener('complete', () => {
-            setOcrStatus('complete');
-            setOcrReady(true);
-            es.close();
-            esRef.current = null;
-        });
-
-        es.addEventListener('error', (ev) => {
-            console.warn('[ocr.sse.client.error]', { ev, jobId });
-            try {
-                const data = JSON.parse((ev as MessageEvent).data) as any;
-                setOcrError(data?.message ?? 'OCR error');
-            } catch {
-                setOcrError('OCR error');
+    const createEventSource = useCallback(
+        (
+            endpoint: string,
+            esRef: React.MutableRefObject<EventSource | null>,
+            setStatus: (v: OcrStatus) => void,
+            setProgress: (v: OcrProgress | null) => void,
+            setReady: (v: boolean) => void,
+            setError: (v: string | null) => void,
+            label: string,
+        ) => {
+            if (esRef.current) {
+                return;
             }
-            setOcrStatus('error');
-            es.close();
-            esRef.current = null;
-        });
-    }, [jobId]);
+            console.info(`[${label}.sse.client.connect]`, { jobId });
+            const es = new EventSource(endpoint);
+            esRef.current = es;
 
+            es.addEventListener('snapshot', (ev) => {
+                const data = JSON.parse((ev as MessageEvent).data) as {
+                    status: OcrStatus;
+                    progress?: OcrProgress | null;
+                };
+                setStatus(data.status);
+                setProgress(data.progress ?? null);
+                setReady(data.status === 'complete');
+            });
+
+            es.addEventListener('progress', (ev) => {
+                const data = JSON.parse((ev as MessageEvent).data) as OcrProgress;
+                setProgress(data);
+                setStatus('running');
+            });
+
+            es.addEventListener('complete', () => {
+                setStatus('complete');
+                setReady(true);
+                es.close();
+                esRef.current = null;
+            });
+
+            es.addEventListener('error', (ev) => {
+                console.warn(`[${label}.sse.client.error]`, { ev, jobId });
+                try {
+                    const data = JSON.parse((ev as MessageEvent).data) as any;
+                    setError(data?.message ?? 'OCR error');
+                } catch {
+                    setError('OCR error');
+                }
+                setStatus('error');
+                es.close();
+                esRef.current = null;
+            });
+        },
+        [jobId],
+    );
+
+    const ensureMacOcrEventSource = useCallback(() => {
+        createEventSource(
+            `/api/jobs/${encodeURIComponent(jobId)}/ocr/events`,
+            macOcrEsRef,
+            setMacOcrStatus,
+            setMacOcrProgress,
+            setMacOcrReady,
+            setMacOcrError,
+            'macOcr',
+        );
+    }, [createEventSource, jobId]);
+
+    const ensureSuryaEventSource = useCallback(() => {
+        createEventSource(
+            `/api/jobs/${encodeURIComponent(jobId)}/surya/events`,
+            suryaEsRef,
+            setSuryaStatus,
+            setSuryaProgress,
+            setSuryaReady,
+            setSuryaError,
+            'surya',
+        );
+    }, [createEventSource, jobId]);
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: jobId is intentionally included to reset state when job changes
     useEffect(() => {
-        // Initialize state when job changes.
-        setOcrStatus('idle');
-        setOcrError(null);
-        setOcrProgress(null);
-        setOcrReady(false);
-        setOcrTextByPage({});
+        // Reset state when job changes
+        setMacOcrStatus('idle');
+        setMacOcrError(null);
+        setMacOcrProgress(null);
+        setMacOcrReady(false);
+        setMacOcrTextByPage({});
+        setSuryaStatus('idle');
+        setSuryaError(null);
+        setSuryaProgress(null);
+        setSuryaReady(false);
+        setSuryaTextByPage({});
 
-        // Close any existing connection for previous job.
-        if (esRef.current) {
-            console.info('[ocr.sse.client.close]', { jobId });
-            esRef.current.close();
-            esRef.current = null;
+        macOcrEsRef.current?.close();
+        macOcrEsRef.current = null;
+        suryaEsRef.current?.close();
+        suryaEsRef.current = null;
+
+        // Connect to SSE immediately
+        if (showMacOcr) {
+            ensureMacOcrEventSource();
         }
-
-        // Connect immediately to observe status even if OCR is started elsewhere.
-        ensureOcrEventSource();
+        if (showSurya) {
+            ensureSuryaEventSource();
+        }
 
         return () => {
-            if (esRef.current) {
-                console.info('[ocr.sse.client.close]', { jobId });
-                esRef.current.close();
-                esRef.current = null;
-            }
+            macOcrEsRef.current?.close();
+            macOcrEsRef.current = null;
+            suryaEsRef.current?.close();
+            suryaEsRef.current = null;
         };
-    }, [ensureOcrEventSource, jobId]);
+    }, [jobId, showMacOcr, showSurya, ensureMacOcrEventSource, ensureSuryaEventSource]);
 
     const runOcr = async () => {
-        setOcrError(null);
-        try {
-            // Ensure we have an SSE connection before starting OCR so we don't miss early events.
-            console.info('[ocr.ui.run]', { jobId });
-            ensureOcrEventSource();
-            const res = await fetch(`/api/jobs/${encodeURIComponent(jobId)}/ocr`, { method: 'POST' });
-            if (!res.ok) {
-                const body = await res.json().catch(() => null);
-                throw new Error(body?.error ?? `Failed to start OCR (${res.status})`);
-            }
-            setOcrStatus('running');
-            // Fallback: one-shot status sync in case SSE is blocked by the browser or dev tooling.
-            scheduleOcrStatusSyncs({ jobId, setOcrError, setOcrReady, setOcrStatus });
-        } catch (err: unknown) {
-            setOcrError(err instanceof Error ? err.message : 'Failed to start OCR');
-            setOcrStatus('error');
+        setMacOcrError(null);
+        setSuryaError(null);
+
+        const promises: Promise<void>[] = [];
+
+        if (showMacOcr) {
+            ensureMacOcrEventSource();
+            promises.push(
+                (async () => {
+                    const res = await fetch(`/api/jobs/${encodeURIComponent(jobId)}/ocr`, { method: 'POST' });
+                    if (!res.ok) {
+                        const body = await res.json().catch(() => null);
+                        throw new Error(body?.error ?? `Failed to start macOCR (${res.status})`);
+                    }
+                    setMacOcrStatus('running');
+                    scheduleOcrStatusSyncs({
+                        endpoint: `/api/jobs/${encodeURIComponent(jobId)}/ocr`,
+                        setOcrError: setMacOcrError,
+                        setOcrReady: setMacOcrReady,
+                        setOcrStatus: setMacOcrStatus,
+                    });
+                })().catch((err) => setMacOcrError(err.message)),
+            );
         }
+
+        if (showSurya) {
+            ensureSuryaEventSource();
+            promises.push(
+                (async () => {
+                    const res = await fetch(`/api/jobs/${encodeURIComponent(jobId)}/surya`, { method: 'POST' });
+                    if (!res.ok) {
+                        const body = await res.json().catch(() => null);
+                        throw new Error(body?.error ?? `Failed to start Surya (${res.status})`);
+                    }
+                    setSuryaStatus('running');
+                    scheduleOcrStatusSyncs({
+                        endpoint: `/api/jobs/${encodeURIComponent(jobId)}/surya`,
+                        setOcrError: setSuryaError,
+                        setOcrReady: setSuryaReady,
+                        setOcrStatus: setSuryaStatus,
+                    });
+                })().catch((err) => setSuryaError(err.message)),
+            );
+        }
+
+        await Promise.all(promises);
     };
 
+    // Fetch macOCR text for pages
     useEffect(() => {
-        if (!ocrReady) {
+        if (!macOcrReady) {
             return;
         }
         const controller = new AbortController();
-
         void (async () => {
-            try {
-                for (const p of previewPages) {
-                    if (controller.signal.aborted) {
-                        return;
-                    }
-                    if (p > extractedPages) {
-                        continue;
-                    }
-                    if (ocrTextByPage[p]) {
-                        continue;
-                    }
-                    const text = await fetchOcrTextForPage(jobId, p, controller.signal);
-                    if (!text) {
-                        continue;
-                    }
-                    setOcrTextByPage((m) => ({ ...m, [p]: text }));
+            for (const p of previewPages) {
+                if (controller.signal.aborted || p > extractedPages || macOcrTextByPage[p]) {
+                    continue;
                 }
-            } catch (err: unknown) {
-                if (err instanceof Error && err.name === 'AbortError') {
-                    return;
+                const text = await fetchOcrTextForPage(jobId, p, 'ocr', controller.signal);
+                if (text) {
+                    setMacOcrTextByPage((m) => ({ ...m, [p]: text }));
                 }
-                // ignore other errors; rows will stay in "Loading…" and can be retried on rerender
             }
         })();
-
         return () => controller.abort();
-    }, [extractedPages, jobId, ocrReady, ocrTextByPage, previewPages]);
+    }, [extractedPages, jobId, macOcrReady, macOcrTextByPage, previewPages]);
 
-    const progressLabel =
-        ocrProgress?.currentPage && ocrProgress?.totalPages
-            ? `Processing page ${ocrProgress.currentPage} of ${ocrProgress.totalPages}…`
-            : (ocrProgress?.line ?? null);
+    // Fetch Surya text for pages
+    useEffect(() => {
+        if (!suryaReady) {
+            return;
+        }
+        const controller = new AbortController();
+        void (async () => {
+            for (const p of previewPages) {
+                if (controller.signal.aborted || p > extractedPages || suryaTextByPage[p]) {
+                    continue;
+                }
+                const text = await fetchOcrTextForPage(jobId, p, 'surya', controller.signal);
+                if (text) {
+                    setSuryaTextByPage((m) => ({ ...m, [p]: text }));
+                }
+            }
+        })();
+        return () => controller.abort();
+    }, [extractedPages, jobId, suryaReady, suryaTextByPage, previewPages]);
+
+    const formatProgressLabel = (progress: OcrProgress | null, status: OcrStatus, label: string): string | null => {
+        if (status !== 'running') {
+            return null;
+        }
+        // Show the actual line with percentage info if available
+        if (progress?.line) {
+            return `${label}: ${progress.line}`;
+        }
+        if (progress?.currentPage && progress?.totalPages) {
+            return `${label}: Page ${progress.currentPage} of ${progress.totalPages}`;
+        }
+        return null;
+    };
+
+    const macOcrProgressLabel = formatProgressLabel(macOcrProgress, macOcrStatus, 'macOCR');
+    const suryaProgressLabel = formatProgressLabel(suryaProgress, suryaStatus, 'Surya');
+
+    const isRunning = (showMacOcr && macOcrStatus === 'running') || (showSurya && suryaStatus === 'running');
 
     return (
         <div className="flex flex-col gap-4">
@@ -297,27 +453,53 @@ export function PageOcrTable({
                     </div>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
-                    <Button type="button" variant="secondary" onClick={runOcr} disabled={ocrStatus === 'running'}>
-                        {ocrStatus === 'running' ? 'Running OCR…' : 'Run OCR'}
+                    <select
+                        value={selectedEngine}
+                        onChange={(e) => setSelectedEngine(e.target.value as OcrEngine)}
+                        className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+                    >
+                        <option value="both">Both Engines</option>
+                        <option value="macOCR">macOCR Only</option>
+                        <option value="surya">Surya Only</option>
+                    </select>
+                    <Button type="button" variant="secondary" onClick={runOcr} disabled={isRunning}>
+                        {isRunning ? 'Running OCR…' : 'Run OCR'}
                     </Button>
-                    <div className="text-xs text-zinc-600 dark:text-zinc-400">OCR: {ocrStatus}</div>
                 </div>
             </div>
 
-            {progressLabel ? <div className="text-xs text-zinc-600 dark:text-zinc-400">{progressLabel}</div> : null}
-            {ocrError ? <div className="text-red-600 text-sm dark:text-red-400">{ocrError}</div> : null}
+            {/* Progress and status display */}
+            <div className="flex flex-wrap gap-4 text-xs text-zinc-600 dark:text-zinc-400">
+                {showMacOcr && (
+                    <div>
+                        <span className="font-medium">macOCR:</span> {macOcrStatus}
+                        {macOcrProgressLabel && <span className="ml-2">{macOcrProgressLabel}</span>}
+                    </div>
+                )}
+                {showSurya && (
+                    <div>
+                        <span className="font-medium">Surya:</span> {suryaStatus}
+                        {suryaProgressLabel && <span className="ml-2">{suryaProgressLabel}</span>}
+                    </div>
+                )}
+            </div>
+
+            {macOcrError && <div className="text-red-600 text-sm dark:text-red-400">macOCR: {macOcrError}</div>}
+            {suryaError && <div className="text-red-600 text-sm dark:text-red-400">Surya: {suryaError}</div>}
 
             <Table className="table-fixed">
                 <colgroup>
                     <col style={{ width: 80 }} />
                     <col style={{ width: 300 }} />
-                    <col />
+                    {showMacOcr && <col />}
+                    {showSurya && <col />}
                 </colgroup>
                 <TableHeader>
                     <TableRow>
                         <TableHead>Page</TableHead>
                         <TableHead>Image</TableHead>
-                        <TableHead>OCR text</TableHead>
+                        {showMacOcr && <TableHead>macOCR</TableHead>}
+                        {showSurya && <TableHead>Surya</TableHead>}
                     </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -329,8 +511,12 @@ export function PageOcrTable({
                             extractedPages={extractedPages}
                             onCropPage={onCropPage}
                             clipPath={clipPath}
-                            ocrReady={ocrReady}
-                            ocrText={ocrTextByPage[p]}
+                            macOcrReady={macOcrReady}
+                            macOcrText={macOcrTextByPage[p]}
+                            suryaReady={suryaReady}
+                            suryaText={suryaTextByPage[p]}
+                            showMacOcr={showMacOcr}
+                            showSurya={showSurya}
                         />
                     ))}
                 </TableBody>

--- a/src/lib/suryaOcr.ts
+++ b/src/lib/suryaOcr.ts
@@ -1,0 +1,37 @@
+/**
+ * TypeScript types for Surya OCR output.
+ * Based on the filtered surya.json format after stripping character-level data.
+ */
+
+/** Axis-aligned bounding box in (x1, y1, x2, y2) format */
+export type SuryaBBox = [number, number, number, number];
+
+/** A single text line detected by Surya */
+export type SuryaTextLine = {
+    /** the axis-aligned rectangle for the text line in (x1, y1, x2, y2) format */
+    readonly bbox: SuryaBBox;
+    /** the text in the line */
+    readonly text: string;
+};
+
+/** OCR result for a single page */
+export type SuryaPageOcrResult = {
+    /** The bbox for the image in (x1, y1, x2, y2) format */
+    readonly image_bbox: SuryaBBox;
+    /** The page number in the file (0-indexed from surya) */
+    readonly page: number;
+    /** The detected text and bounding boxes for each line */
+    readonly text_lines: SuryaTextLine[];
+};
+
+/**
+ * Raw surya results.json output before filtering.
+ * Record where key is filename without extension, value is array of page results.
+ */
+export type SuryaRawOutput = Record<string, SuryaPageOcrResult[]>;
+
+/**
+ * Filtered surya.json output after jq-like processing.
+ * Same structure but with character-level data stripped.
+ */
+export type SuryaOcrOutput = Record<string, SuryaPageOcrResult[]>;

--- a/src/server/jobs/jobStore.ts
+++ b/src/server/jobs/jobStore.ts
@@ -23,6 +23,8 @@ export type Job = {
     error?: string;
     // Optional; default behavior should treat missing as {status:'idle'}.
     ocr?: JobOcr;
+    // Optional; surya OCR status tracked separately for parallel execution.
+    suryaOcr?: JobOcr;
     // Optional; informational only (dedupe is by content hash).
     sourceUrl?: string;
 };

--- a/src/server/ocr/ocrEventBus.ts
+++ b/src/server/ocr/ocrEventBus.ts
@@ -1,6 +1,11 @@
 import { EventEmitter } from 'node:events';
 
-export type OcrProgressEvent = { line: string; currentPage?: number; totalPages?: number };
+export type OcrProgressEvent = {
+    line: string;
+    currentPage?: number;
+    totalPages?: number;
+    phase?: 'detecting' | 'recognizing'; // surya-specific phases
+};
 
 export type OcrEvents = {
     progress: (ev: OcrProgressEvent) => void;
@@ -32,6 +37,8 @@ class OcrEventBus {
 const G = globalThis as typeof globalThis & {
     __ocrBuses?: Map<string, OcrEventBus>;
     __ocrLastProgress?: Map<string, OcrProgressEvent>;
+    __suryaBuses?: Map<string, OcrEventBus>;
+    __suryaLastProgress?: Map<string, OcrProgressEvent>;
 };
 if (!G.__ocrBuses) {
     G.__ocrBuses = new Map();
@@ -39,10 +46,19 @@ if (!G.__ocrBuses) {
 if (!G.__ocrLastProgress) {
     G.__ocrLastProgress = new Map();
 }
+if (!G.__suryaBuses) {
+    G.__suryaBuses = new Map();
+}
+if (!G.__suryaLastProgress) {
+    G.__suryaLastProgress = new Map();
+}
 
 const buses = G.__ocrBuses;
 const lastProgress = G.__ocrLastProgress;
+const suryaBuses = G.__suryaBuses;
+const suryaLastProgress = G.__suryaLastProgress;
 
+// macOCR event bus functions
 export function ocrBus(jobId: string): OcrEventBus {
     const existing = buses.get(jobId);
     if (existing) {
@@ -73,5 +89,44 @@ export function emitOcrComplete(jobId: string): void {
 export function emitOcrError(jobId: string, message: string): void {
     const bus = ocrBus(jobId);
     console.info('[ocrEventBus.error]', { jobId, listeners: bus.listenerCount('error'), message });
+    bus.emit('error', message);
+}
+
+// Surya event bus functions
+export function suryaBus(jobId: string): OcrEventBus {
+    const existing = suryaBuses.get(jobId);
+    if (existing) {
+        return existing;
+    }
+    const bus = new OcrEventBus();
+    suryaBuses.set(jobId, bus);
+    return bus;
+}
+
+export function getLastSuryaProgress(jobId: string): OcrProgressEvent | null {
+    return suryaLastProgress.get(jobId) ?? null;
+}
+
+export function emitSuryaProgress(jobId: string, ev: OcrProgressEvent): void {
+    suryaLastProgress.set(jobId, ev);
+    const bus = suryaBus(jobId);
+    console.info('[suryaEventBus.progress]', {
+        jobId,
+        line: ev.line,
+        listeners: bus.listenerCount('progress'),
+        phase: ev.phase,
+    });
+    bus.emit('progress', ev);
+}
+
+export function emitSuryaComplete(jobId: string): void {
+    const bus = suryaBus(jobId);
+    console.info('[suryaEventBus.complete]', { jobId, listeners: bus.listenerCount('complete') });
+    bus.emit('complete');
+}
+
+export function emitSuryaError(jobId: string, message: string): void {
+    const bus = suryaBus(jobId);
+    console.info('[suryaEventBus.error]', { jobId, listeners: bus.listenerCount('error'), message });
     bus.emit('error', message);
 }

--- a/src/server/ocr/ocrPaths.ts
+++ b/src/server/ocr/ocrPaths.ts
@@ -20,3 +20,24 @@ export function jobOcrMetaPath(jobId: string): string {
 export function jobOcrPagesDir(jobId: string): string {
     return path.join(jobOcrDir(jobId), 'pages');
 }
+
+// Surya OCR paths
+export function jobSuryaOcrDir(jobId: string): string {
+    return path.join(jobDir(jobId), 'surya');
+}
+
+export function jobSuryaResultsJsonPath(jobId: string): string {
+    return path.join(jobSuryaOcrDir(jobId), 'results.json');
+}
+
+export function jobSuryaOcrJsonPath(jobId: string): string {
+    return path.join(jobSuryaOcrDir(jobId), 'surya.json');
+}
+
+export function jobSuryaMetaPath(jobId: string): string {
+    return path.join(jobSuryaOcrDir(jobId), 'meta.json');
+}
+
+export function jobSuryaPagesDir(jobId: string): string {
+    return path.join(jobSuryaOcrDir(jobId), 'pages');
+}

--- a/src/server/ocr/runSuryaOcr.test.ts
+++ b/src/server/ocr/runSuryaOcr.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import * as fsp from 'node:fs/promises';
+import path from 'node:path';
+import { jobDir, jobImagesDir, jobPdfPath } from '@/server/jobs/jobPaths';
+import { JobStore } from '@/server/jobs/jobStore';
+import { suryaBus } from '@/server/ocr/ocrEventBus';
+import { jobSuryaMetaPath, jobSuryaOcrJsonPath, jobSuryaPagesDir } from '@/server/ocr/ocrPaths';
+
+type SpawnMode =
+    | { kind: 'success' }
+    | { kind: 'fail' }
+    | { kind: 'controlled'; close: () => void; fail?: boolean }
+    | { kind: 'mps-fallback' }; // MPS fails, retry with CPU succeeds
+
+let spawnMode: SpawnMode = { kind: 'success' };
+const spawnCalls: Array<{ cmd: string; args: string[]; env?: Record<string, string> }> = [];
+
+async function waitFor(predicate: () => boolean, timeoutMs = 250): Promise<void> {
+    const start = Date.now();
+    while (!predicate()) {
+        if (Date.now() - start > timeoutMs) {
+            throw new Error('waitFor: timeout');
+        }
+        await new Promise((r) => setTimeout(r, 1));
+    }
+}
+
+// Sample surya results.json structure (before filtering)
+const sampleSuryaRawOutput = {
+    input: [
+        {
+            image_bbox: [0, 0, 800, 1000],
+            page: 1, // Surya uses 1-indexed pages
+            text_lines: [
+                {
+                    bbox: [10, 20, 110, 50],
+                    chars: [{ bbox: [10, 20, 20, 50], text: 'ا' }],
+                    confidence: 0.95,
+                    polygon: [
+                        [10, 20],
+                        [110, 20],
+                        [110, 50],
+                        [10, 50],
+                    ],
+                    text: 'السلام عليكم',
+                    words: [{ bbox: [10, 20, 110, 50], text: 'السلام' }],
+                },
+            ],
+        },
+    ],
+};
+
+mock.module('@/server/ocr/spawn', () => {
+    const { EventEmitter } = require('node:events');
+
+    function makeChild() {
+        const child: any = new EventEmitter();
+        child.stdout = new EventEmitter();
+        child.stderr = new EventEmitter();
+        return child;
+    }
+
+    let mpsFailed = false;
+
+    // Expose reset function for tests to call in beforeEach
+    (globalThis as any).__resetMpsFailed = () => {
+        mpsFailed = false;
+    };
+
+    return {
+        spawn: mock((cmd: string, args: string[], options?: { env?: Record<string, string> }) => {
+            spawnCalls.push({ args, cmd, env: options?.env });
+            const child = makeChild();
+            (globalThis as any).__swissawa_lastSpawnChild = child;
+
+            // Extract output dir from bash -c command string
+            // Command format: bash -c "source ... && surya_ocr --disable_math --output_dir \"<dir>\" \"<input>\""
+            const cmdString = args[1] || '';
+            const outputDirMatch = cmdString.match(/--output_dir\s+"([^"]+)"/);
+            const outputDir = outputDirMatch ? outputDirMatch[1] : null;
+
+            const emitSuccess = async () => {
+                // Simulate progress output on stderr
+                child.stderr.emit('data', Buffer.from('Detecting bboxes:  50%|████████\n'));
+                child.stderr.emit('data', Buffer.from('Detecting bboxes: 100%|████████████████\n'));
+                child.stderr.emit('data', Buffer.from('Recognizing Text:  25%|████\n'));
+                child.stderr.emit('data', Buffer.from('Recognizing Text: 100%|████████████████\n'));
+
+                // Write results.json to outputDir/input/results.json (surya's actual output location)
+                if (outputDir) {
+                    const suryaOutDir = path.join(outputDir, 'input');
+                    await fsp.mkdir(suryaOutDir, { recursive: true });
+                    await fsp.writeFile(
+                        path.join(suryaOutDir, 'results.json'),
+                        JSON.stringify(sampleSuryaRawOutput),
+                        'utf8',
+                    );
+                }
+                child.emit('close', 0);
+            };
+
+            const emitFail = () => {
+                child.stderr.emit('data', Buffer.from('Error: CUDA out of memory\n'));
+                child.emit('close', 1);
+            };
+
+            const emitMpsFail = () => {
+                child.stderr.emit('data', Buffer.from('RuntimeError: MPS backend out of memory\n'));
+                child.emit('close', 1);
+            };
+
+            if (spawnMode.kind === 'success') {
+                setTimeout(() => void emitSuccess(), 0);
+            } else if (spawnMode.kind === 'fail') {
+                setTimeout(() => emitFail(), 0);
+            } else if (spawnMode.kind === 'mps-fallback') {
+                if (!mpsFailed) {
+                    mpsFailed = true;
+                    setTimeout(() => emitMpsFail(), 0);
+                } else {
+                    // Second attempt with CPU should succeed
+                    setTimeout(() => void emitSuccess(), 0);
+                }
+            } else {
+                const close = () => {
+                    if (spawnMode.kind !== 'controlled') {
+                        return;
+                    }
+                    if (spawnMode.fail) {
+                        emitFail();
+                    } else {
+                        void emitSuccess();
+                    }
+                };
+                spawnMode.close = close;
+            }
+
+            return child;
+        }),
+    };
+});
+
+// Import after mocking spawn
+import { runSuryaOcr } from '@/server/ocr/runSuryaOcr';
+
+let store: JobStore;
+let jobId = '';
+
+describe('runSuryaOcr', () => {
+    beforeEach(async () => {
+        spawnCalls.length = 0;
+        (globalThis as any).__resetMpsFailed?.();
+        store = new JobStore();
+        jobId = randomUUID();
+
+        await fsp.mkdir(jobDir(jobId), { recursive: true });
+        await fsp.writeFile(jobPdfPath(jobId), '%PDF-1.7 fake', 'utf8');
+
+        store.create({
+            id: jobId,
+            info: undefined,
+            outputDir: jobImagesDir(jobId),
+            pdfPath: jobPdfPath(jobId),
+            progress: { extractedPages: 0, totalPages: 1 },
+            status: 'complete',
+        });
+    });
+
+    afterEach(async () => {
+        if (jobId) {
+            await fsp.rm(jobDir(jobId), { force: true, recursive: true });
+        }
+    });
+
+    it('should spawn surya_ocr with correct args and MPS device', async () => {
+        spawnMode = { kind: 'success' };
+        await runSuryaOcr({ jobId, store });
+
+        expect(spawnCalls.length).toBeGreaterThanOrEqual(1);
+        const call = spawnCalls[0];
+        expect(call?.cmd).toBe('bash');
+        // Args are in the bash command string
+        const cmdString = call?.args[1] || '';
+        expect(cmdString).toContain('surya_ocr');
+        expect(cmdString).toContain('--disable_math');
+        expect(cmdString).toContain('--output_dir');
+        expect(call?.env?.TORCH_DEVICE).toBe('mps');
+    });
+
+    it('should fallback to CPU if MPS fails', async () => {
+        spawnMode = { kind: 'mps-fallback' };
+        await runSuryaOcr({ jobId, store });
+
+        // Should have two spawn calls: first with mps, second with cpu
+        expect(spawnCalls.length).toBe(2);
+        expect(spawnCalls[0]?.env?.TORCH_DEVICE).toBe('mps');
+        expect(spawnCalls[1]?.env?.TORCH_DEVICE).toBe('cpu');
+
+        // Final status should be complete
+        expect(store.get(jobId)?.suryaOcr?.status).toBe('complete');
+    });
+
+    it('should emit progress events for bbox detection and text recognition', async () => {
+        const controlled: SpawnMode = { close: () => {}, kind: 'controlled' };
+        spawnMode = controlled;
+
+        const events: Array<any> = [];
+        const bus = suryaBus(jobId);
+        const onProgress = (ev: any) => events.push(ev);
+        bus.on('progress', onProgress);
+
+        const p = runSuryaOcr({ jobId, store });
+        await waitFor(() => spawnCalls.length === 1);
+
+        const lastChild = (globalThis as any).__swissawa_lastSpawnChild as any;
+        expect(lastChild).toBeTruthy();
+
+        // Simulate surya progress
+        lastChild.stderr.emit('data', Buffer.from('Detecting bboxes:  20%|████\n'));
+        await waitFor(() => events.length >= 1);
+        expect(events[0]?.line).toContain('Detecting bboxes');
+        expect(events[0]?.phase).toBe('detecting');
+
+        lastChild.stderr.emit('data', Buffer.from('Recognizing Text:  50%|████████\n'));
+        await waitFor(() => events.length >= 2);
+        expect(events[1]?.line).toContain('Recognizing Text');
+        expect(events[1]?.phase).toBe('recognizing');
+
+        controlled.close();
+        await p;
+        bus.off('progress', onProgress);
+    });
+
+    it('should filter results.json and write surya.json without char-level data', async () => {
+        spawnMode = { kind: 'success' };
+        await runSuryaOcr({ jobId, store });
+
+        const suryaJson = JSON.parse(await fsp.readFile(jobSuryaOcrJsonPath(jobId), 'utf8'));
+
+        // Should have the filtered structure
+        expect(suryaJson.input).toBeDefined();
+        expect(suryaJson.input[0].text_lines[0]).not.toHaveProperty('chars');
+        expect(suryaJson.input[0].text_lines[0]).not.toHaveProperty('confidence');
+        expect(suryaJson.input[0].text_lines[0]).not.toHaveProperty('polygon');
+        expect(suryaJson.input[0].text_lines[0]).not.toHaveProperty('words');
+        expect(suryaJson.input[0].text_lines[0].text).toBe('السلام عليكم');
+    });
+
+    it('should write per-page JSON files and meta.json', async () => {
+        spawnMode = { kind: 'success' };
+        await runSuryaOcr({ jobId, store });
+
+        const meta = JSON.parse(await fsp.readFile(jobSuryaMetaPath(jobId), 'utf8'));
+        expect(meta.totalPages).toBe(1);
+
+        const page1 = JSON.parse(await fsp.readFile(path.join(jobSuryaPagesDir(jobId), '1.json'), 'utf8'));
+        expect(page1.page).toBe(1);
+        expect(page1.observations[0]?.text).toBe('السلام عليكم');
+    });
+
+    it('should mark job suryaOcr status as complete on success', async () => {
+        spawnMode = { kind: 'success' };
+        await runSuryaOcr({ jobId, store });
+
+        expect(store.get(jobId)?.suryaOcr?.status).toBe('complete');
+    });
+
+    it('should mark job suryaOcr status as error on failure', async () => {
+        spawnMode = { kind: 'fail' };
+        await expect(runSuryaOcr({ jobId, store })).rejects.toThrow();
+
+        expect(store.get(jobId)?.suryaOcr?.status).toBe('error');
+        expect(store.get(jobId)?.suryaOcr?.error).toBeDefined();
+    });
+
+    it('should not spawn twice if called while already running', async () => {
+        const controlled: SpawnMode = { close: () => {}, kind: 'controlled' };
+        spawnMode = controlled;
+
+        const p1 = runSuryaOcr({ jobId, store });
+        const p2 = runSuryaOcr({ jobId, store });
+
+        await waitFor(() => spawnCalls.length === 1);
+        expect(spawnCalls.length).toBe(1);
+
+        controlled.close();
+        await expect(Promise.all([p1, p2])).resolves.toBeDefined();
+        expect(spawnCalls.length).toBe(1);
+    });
+
+    it('should allow re-run after completion', async () => {
+        spawnMode = { kind: 'success' };
+        await runSuryaOcr({ jobId, store });
+        await runSuryaOcr({ jobId, store });
+        expect(spawnCalls.length).toBe(2);
+    });
+
+    it('should use virtual environment activation', async () => {
+        spawnMode = { kind: 'success' };
+        await runSuryaOcr({ jobId, store });
+
+        const call = spawnCalls[0];
+        // Should use bash -c with source activation
+        expect(call?.cmd).toBe('bash');
+        expect(call?.args[0]).toBe('-c');
+        expect(call?.args[1]).toContain('source');
+        expect(call?.args[1]).toContain('surya-env');
+    });
+});

--- a/src/server/ocr/runSuryaOcr.ts
+++ b/src/server/ocr/runSuryaOcr.ts
@@ -1,0 +1,215 @@
+import * as fsp from 'node:fs/promises';
+import path from 'node:path';
+import { isFullCropBox, normalizeCropBox } from '@/lib/cropConvert';
+import type { SuryaOcrOutput, SuryaPageOcrResult } from '@/lib/suryaOcr';
+import { readCropBox } from '@/server/crop/cropStore';
+import { jobPdfPath } from '@/server/jobs/jobPaths';
+import { writeJobSnapshot } from '@/server/jobs/jobSnapshot';
+import type { JobOcr, JobStore } from '@/server/jobs/jobStore';
+import { emitSuryaComplete, emitSuryaError, emitSuryaProgress } from '@/server/ocr/ocrEventBus';
+import { jobSuryaOcrDir, jobSuryaOcrJsonPath } from '@/server/ocr/ocrPaths';
+import { spawn } from '@/server/ocr/spawn';
+import { filterSuryaRawOutput, splitSuryaOcrToPages } from '@/server/ocr/splitSuryaOcr';
+import { cropPdfBytes } from '@/server/pdf/cropPdf';
+
+export type RunSuryaOcrParams = {
+    jobId: string;
+    store: JobStore;
+    splitPages?: boolean; // default: true
+};
+
+const runningByJobId = new Map<string, Promise<void>>();
+
+const SURYA_VENV_PATH = '~/surya-env/bin/activate';
+
+async function getSuryaInputPdfBytes(jobId: string, store: JobStore): Promise<Uint8Array> {
+    const job = store.get(jobId);
+    if (!job) {
+        throw new Error(`Job not found: ${jobId}`);
+    }
+    const original = await fsp.readFile(job.pdfPath ?? jobPdfPath(jobId));
+    const crop = job.crop ?? (await readCropBox(jobId));
+    if (!crop) {
+        return original;
+    }
+    const normalized = normalizeCropBox(crop);
+    if (isFullCropBox(normalized)) {
+        return original;
+    }
+    return await cropPdfBytes(original, normalized, { shrinkPage: true });
+}
+
+async function updateSuryaOcrStatus(store: JobStore, jobId: string, updater: (current: JobOcr) => void): Promise<void> {
+    const updated = store.update(jobId, (j) => {
+        const current: JobOcr = j.suryaOcr ?? { status: 'idle', updatedAtMs: Date.now() };
+        const next: JobOcr = { ...current, updatedAtMs: Date.now() };
+        updater(next);
+        j.suryaOcr = next;
+    });
+    await writeJobSnapshot(updated);
+}
+
+type LineState = { buf: string };
+
+function handleSuryaStreamChunk(params: { jobId: string; state: LineState; chunk: Buffer }): void {
+    params.state.buf += params.chunk.toString('utf8');
+    params.state.buf = params.state.buf.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+
+    while (true) {
+        const idx = params.state.buf.indexOf('\n');
+        if (idx < 0) {
+            break;
+        }
+
+        const line = params.state.buf.slice(0, idx).trimEnd();
+        params.state.buf = params.state.buf.slice(idx + 1);
+        if (!line) {
+            continue;
+        }
+
+        // Parse surya progress patterns:
+        // "Detecting bboxes:  50%|████████" or "Detecting bboxes: 2/5 [00:07<00:30, 7.65s/it]"
+        // "Recognizing Text:  25%|████" or "Recognizing Text: 4/697 [00:07<14:26, 1.25s/it]"
+        const detectingMatch =
+            line.match(/Detecting bboxes:\s*(\d+)%/i) || line.match(/Detecting bboxes:\s*(\d+)\/(\d+)/i);
+        const recognizingMatch =
+            line.match(/Recognizing Text:\s*(\d+)%/i) || line.match(/Recognizing Text:\s*(\d+)\/(\d+)/i);
+
+        if (detectingMatch) {
+            emitSuryaProgress(params.jobId, { line, phase: 'detecting' });
+        } else if (recognizingMatch) {
+            emitSuryaProgress(params.jobId, { line, phase: 'recognizing' });
+        } else if (line.includes('Downloading') || line.includes('surya:')) {
+            // Info lines like model downloads or final output message
+            emitSuryaProgress(params.jobId, { line });
+        }
+    }
+}
+
+async function spawnSuryaOcr(params: {
+    jobId: string;
+    inputPdfPath: string;
+    outputDir: string;
+    device: 'mps' | 'cpu';
+}): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        // Build command to run in virtual environment
+        const suryaCmd = `source ${SURYA_VENV_PATH} && surya_ocr --disable_math --output_dir "${params.outputDir}" "${params.inputPdfPath}"`;
+        const args = ['-c', suryaCmd];
+        const env = { ...process.env, TORCH_DEVICE: params.device };
+
+        console.info('[surya.run.spawn]', { device: params.device, jobId: params.jobId, outputDir: params.outputDir });
+        const child = spawn('bash', args, { env, stdio: ['ignore', 'pipe', 'pipe'] });
+
+        const outState: LineState = { buf: '' };
+        const errState: LineState = { buf: '' };
+        let stderr = '';
+
+        child.stdout?.on('data', (d: Buffer) => {
+            handleSuryaStreamChunk({ chunk: d, jobId: params.jobId, state: outState });
+        });
+        child.stderr?.on('data', (d: Buffer) => {
+            stderr += d.toString('utf8');
+            handleSuryaStreamChunk({ chunk: d, jobId: params.jobId, state: errState });
+        });
+        child.on('error', reject);
+        child.on('close', (code: number | null) => {
+            console.info('[surya.run.exit]', { code, jobId: params.jobId });
+            if (code === 0) {
+                resolve();
+                return;
+            }
+            reject(new Error(`surya_ocr exited with code ${code ?? 'null'}: ${stderr}`));
+        });
+    });
+}
+
+export async function runSuryaOcr(params: RunSuryaOcrParams): Promise<void> {
+    const existing = runningByJobId.get(params.jobId);
+    if (existing) {
+        return existing;
+    }
+
+    const promise = (async () => {
+        const job = params.store.get(params.jobId);
+        if (!job) {
+            throw new Error(`Job not found: ${params.jobId}`);
+        }
+
+        const splitPages = params.splitPages ?? true;
+
+        console.info('[surya.run.start]', { jobId: params.jobId, splitPages });
+        await updateSuryaOcrStatus(params.store, params.jobId, (ocr) => {
+            ocr.status = 'running';
+            delete ocr.error;
+        });
+
+        const suryaDir = jobSuryaOcrDir(params.jobId);
+        await fsp.mkdir(suryaDir, { recursive: true });
+
+        // Write cropped PDF to surya input directory
+        const inputPdfBytes = await getSuryaInputPdfBytes(params.jobId, params.store);
+        const inputPdfPath = path.join(suryaDir, 'input.pdf');
+        await fsp.writeFile(inputPdfPath, inputPdfBytes);
+
+        // Try MPS first, fallback to CPU if it fails
+        let device: 'mps' | 'cpu' = 'mps';
+        try {
+            await spawnSuryaOcr({ device, inputPdfPath, jobId: params.jobId, outputDir: suryaDir });
+        } catch (err: unknown) {
+            const errMsg = err instanceof Error ? err.message : String(err);
+            if (errMsg.includes('MPS') || errMsg.includes('mps') || errMsg.includes('Metal')) {
+                console.warn('[surya.run.mps_fallback]', { jobId: params.jobId, reason: errMsg });
+                device = 'cpu';
+                await spawnSuryaOcr({ device, inputPdfPath, jobId: params.jobId, outputDir: suryaDir });
+            } else {
+                throw err;
+            }
+        }
+
+        // Surya outputs to: outputDir/<input-basename>/results.json
+        // Since we name our input "input.pdf", the results go to suryaDir/input/results.json
+        const resultsJsonPath = path.join(suryaDir, 'input', 'results.json');
+        const rawJson = await fsp.readFile(resultsJsonPath, 'utf8');
+        const rawOutput = JSON.parse(rawJson) as SuryaOcrOutput;
+
+        // Filter to remove char-level data
+        const filteredOutput = filterSuryaRawOutput(rawOutput);
+
+        // Write filtered surya.json
+        await fsp.writeFile(jobSuryaOcrJsonPath(params.jobId), JSON.stringify(filteredOutput, null, 2), 'utf8');
+
+        // Get pages array from the first (and usually only) file key
+        const fileKeys = Object.keys(filteredOutput);
+        const pages: SuryaPageOcrResult[] = fileKeys.length > 0 ? (filteredOutput[fileKeys[0]] ?? []) : [];
+
+        if (splitPages) {
+            await splitSuryaOcrToPages({ outDir: suryaDir, pages });
+        }
+
+        await updateSuryaOcrStatus(params.store, params.jobId, (s) => {
+            s.status = 'complete';
+            s.meta = { createdAtIso: new Date().toISOString(), dpi: { x: 72, y: 72 }, totalPages: pages.length };
+        });
+        emitSuryaComplete(params.jobId);
+        console.info('[surya.run.complete]', { jobId: params.jobId, totalPages: pages.length });
+    })()
+        .catch(async (err: unknown) => {
+            await updateSuryaOcrStatus(params.store, params.jobId, (s) => {
+                s.status = 'error';
+                s.error = err instanceof Error ? err.message : 'Surya OCR failed';
+            });
+            emitSuryaError(params.jobId, err instanceof Error ? err.message : 'Surya OCR failed');
+            console.error('[surya.run.error]', {
+                jobId: params.jobId,
+                message: err instanceof Error ? err.message : String(err),
+            });
+            throw err;
+        })
+        .finally(() => {
+            runningByJobId.delete(params.jobId);
+        });
+
+    runningByJobId.set(params.jobId, promise);
+    return promise;
+}

--- a/src/server/ocr/splitSuryaOcr.test.ts
+++ b/src/server/ocr/splitSuryaOcr.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import * as fsp from 'node:fs/promises';
+import path from 'node:path';
+import type { ObservationPage } from '@/lib/macOcr';
+import type { SuryaPageOcrResult } from '@/lib/suryaOcr';
+import { jobDir } from '@/server/jobs/jobPaths';
+import {
+    convertSuryaToObservationPage,
+    filterSuryaRawOutput,
+    splitSuryaOcrToPages,
+    writeSuryaMeta,
+} from '@/server/ocr/splitSuryaOcr';
+
+let testJobId = '';
+
+describe('splitSuryaOcr', () => {
+    beforeEach(async () => {
+        testJobId = randomUUID();
+        await fsp.mkdir(jobDir(testJobId), { recursive: true });
+    });
+
+    afterEach(async () => {
+        if (testJobId) {
+            await fsp.rm(jobDir(testJobId), { force: true, recursive: true });
+        }
+    });
+
+    describe('filterSuryaRawOutput', () => {
+        it('should strip chars, confidence, polygon, words, and original_text_good from text_lines', () => {
+            const rawPage = {
+                image_bbox: [0, 0, 800, 1000] as [number, number, number, number],
+                page: 1, // Surya uses 1-indexed pages
+                text_lines: [
+                    {
+                        bbox: [10, 20, 100, 40] as [number, number, number, number],
+                        chars: [{ bbox: [10, 20, 15, 40], text: 'a' }],
+                        confidence: 0.95,
+                        original_text_good: true,
+                        polygon: [
+                            [10, 20],
+                            [100, 20],
+                            [100, 40],
+                            [10, 40],
+                        ],
+                        text: 'مرحبا',
+                        words: [{ bbox: [10, 20, 100, 40], text: 'مرحبا' }],
+                    },
+                ],
+            };
+
+            const result = filterSuryaRawOutput({ 'test-file': [rawPage as any] });
+
+            expect(result).toEqual({
+                'test-file': [
+                    {
+                        image_bbox: [0, 0, 800, 1000],
+                        page: 1,
+                        text_lines: [{ bbox: [10, 20, 100, 40], text: 'مرحبا' }],
+                    },
+                ],
+            });
+        });
+
+        it('should handle multiple pages and files', () => {
+            const raw = {
+                file1: [
+                    {
+                        image_bbox: [0, 0, 100, 100] as [number, number, number, number],
+                        page: 1,
+                        text_lines: [{ bbox: [0, 0, 10, 10], confidence: 0.9, text: 'a' }],
+                    },
+                    {
+                        image_bbox: [0, 0, 100, 100] as [number, number, number, number],
+                        page: 2,
+                        text_lines: [{ bbox: [0, 0, 10, 10], confidence: 0.8, text: 'b' }],
+                    },
+                ],
+                file2: [{ image_bbox: [0, 0, 200, 200] as [number, number, number, number], page: 1, text_lines: [] }],
+            };
+
+            const result = filterSuryaRawOutput(raw as any);
+
+            expect(Object.keys(result)).toEqual(['file1', 'file2']);
+            expect(result.file1?.length).toBe(2);
+            expect(result.file2?.length).toBe(1);
+            expect(result.file1?.[0]?.text_lines[0]).not.toHaveProperty('confidence');
+        });
+    });
+
+    describe('convertSuryaToObservationPage', () => {
+        it('should convert SuryaPageOcrResult to ObservationPage format', () => {
+            const suryaPage: SuryaPageOcrResult = {
+                image_bbox: [0, 0, 800, 1200],
+                page: 1, // Surya uses 1-indexed pages
+                text_lines: [
+                    { bbox: [10, 20, 110, 50], text: 'السلام عليكم' },
+                    { bbox: [10, 60, 200, 90], text: 'وعليكم السلام' },
+                ],
+            };
+
+            const result = convertSuryaToObservationPage(suryaPage);
+
+            expect(result).toEqual({
+                height: 1200,
+                observations: [
+                    { bbox: { height: 30, width: 100, x: 10, y: 20 }, text: 'السلام عليكم' },
+                    { bbox: { height: 30, width: 190, x: 10, y: 60 }, text: 'وعليكم السلام' },
+                ],
+                page: 1, // Same as input - surya is already 1-indexed
+                width: 800,
+            });
+        });
+
+        it('should handle empty text_lines', () => {
+            const suryaPage: SuryaPageOcrResult = { image_bbox: [0, 0, 500, 700], page: 5, text_lines: [] };
+
+            const result = convertSuryaToObservationPage(suryaPage);
+
+            expect(result).toEqual({
+                height: 700,
+                observations: [],
+                page: 5, // Same as input
+                width: 500,
+            });
+        });
+    });
+
+    describe('writeSuryaMeta', () => {
+        it('should write meta.json with correct fields', async () => {
+            const outDir = path.join(jobDir(testJobId), 'surya');
+            await fsp.mkdir(outDir, { recursive: true });
+
+            const meta = { createdAtIso: '2026-01-04T00:00:00Z', dpi: { x: 72, y: 72 }, totalPages: 5 };
+            await writeSuryaMeta(outDir, meta);
+
+            const written = JSON.parse(await fsp.readFile(path.join(outDir, 'meta.json'), 'utf8'));
+            expect(written.totalPages).toBe(5);
+            expect(written.createdAtIso).toBe('2026-01-04T00:00:00Z');
+        });
+    });
+
+    describe('splitSuryaOcrToPages', () => {
+        it('should split surya output into per-page JSON files', async () => {
+            const suryaPages: SuryaPageOcrResult[] = [
+                {
+                    image_bbox: [0, 0, 800, 1000],
+                    page: 1, // Surya uses 1-indexed pages
+                    text_lines: [{ bbox: [10, 20, 100, 40], text: 'صفحة واحدة' }],
+                },
+                {
+                    image_bbox: [0, 0, 800, 1000],
+                    page: 2,
+                    text_lines: [{ bbox: [10, 20, 100, 40], text: 'صفحة اثنين' }],
+                },
+            ];
+
+            const outDir = path.join(jobDir(testJobId), 'surya');
+            const meta = await splitSuryaOcrToPages({ outDir, pages: suryaPages });
+
+            expect(meta.totalPages).toBe(2);
+
+            // Check per-page files exist with correct content
+            const page1 = JSON.parse(
+                await fsp.readFile(path.join(outDir, 'pages', '1.json'), 'utf8'),
+            ) as ObservationPage;
+            expect(page1.page).toBe(1);
+            expect(page1.observations[0]?.text).toBe('صفحة واحدة');
+
+            const page2 = JSON.parse(
+                await fsp.readFile(path.join(outDir, 'pages', '2.json'), 'utf8'),
+            ) as ObservationPage;
+            expect(page2.page).toBe(2);
+            expect(page2.observations[0]?.text).toBe('صفحة اثنين');
+
+            // Check meta.json
+            const writtenMeta = JSON.parse(await fsp.readFile(path.join(outDir, 'meta.json'), 'utf8'));
+            expect(writtenMeta.totalPages).toBe(2);
+        });
+
+        it('should handle empty pages array', async () => {
+            const outDir = path.join(jobDir(testJobId), 'surya');
+            const meta = await splitSuryaOcrToPages({ outDir, pages: [] });
+
+            expect(meta.totalPages).toBe(0);
+
+            const pagesDir = path.join(outDir, 'pages');
+            const files = await fsp.readdir(pagesDir);
+            expect(files.length).toBe(0);
+        });
+    });
+});

--- a/src/server/ocr/splitSuryaOcr.ts
+++ b/src/server/ocr/splitSuryaOcr.ts
@@ -1,0 +1,97 @@
+import * as fsp from 'node:fs/promises';
+import path from 'node:path';
+import type { BoundingBox, Observation, ObservationPage } from '@/lib/macOcr';
+import type { SuryaOcrOutput, SuryaPageOcrResult, SuryaRawOutput, SuryaTextLine } from '@/lib/suryaOcr';
+
+export type SuryaOcrMeta = { totalPages: number; dpi: { x: number; y: number }; createdAtIso: string };
+
+export type SplitSuryaOcrOptions = { outDir: string; pages: SuryaPageOcrResult[] };
+
+/**
+ * Filter raw surya results.json output by stripping character-level data.
+ * Removes: chars, confidence, polygon, words, original_text_good from text_lines.
+ */
+export function filterSuryaRawOutput(raw: SuryaRawOutput): SuryaOcrOutput {
+    const result: SuryaOcrOutput = {};
+
+    for (const [filename, pages] of Object.entries(raw)) {
+        result[filename] = pages.map((page) => ({
+            image_bbox: page.image_bbox,
+            page: page.page,
+            text_lines: page.text_lines.map((line: any) => ({ bbox: line.bbox, text: line.text })),
+        }));
+    }
+
+    return result;
+}
+
+/**
+ * Convert surya bbox format [x1, y1, x2, y2] to macOCR BoundingBox { x, y, width, height }.
+ */
+function suryaBboxToBoundingBox(bbox: [number, number, number, number]): BoundingBox {
+    const [x1, y1, x2, y2] = bbox;
+    return { height: y2 - y1, width: x2 - x1, x: x1, y: y1 };
+}
+
+/**
+ * Convert SuryaPageOcrResult to ObservationPage format for unified page rendering.
+ * Note: Surya pages are already 1-indexed based on results.json output.
+ */
+export function convertSuryaToObservationPage(suryaPage: SuryaPageOcrResult): ObservationPage {
+    const [, , width, height] = suryaPage.image_bbox;
+
+    const observations: Observation[] = suryaPage.text_lines.map((line: SuryaTextLine) => ({
+        bbox: suryaBboxToBoundingBox(line.bbox),
+        text: line.text,
+    }));
+
+    return {
+        height,
+        observations,
+        page: suryaPage.page, // Surya is already 1-indexed
+        width,
+    };
+}
+
+/**
+ * Build metadata for surya OCR results.
+ * Surya doesn't provide DPI info, so we default to 72.
+ */
+export function buildSuryaMeta(pages: SuryaPageOcrResult[]): SuryaOcrMeta {
+    return { createdAtIso: new Date().toISOString(), dpi: { x: 72, y: 72 }, totalPages: pages.length };
+}
+
+/**
+ * Write surya meta.json to the output directory.
+ */
+export async function writeSuryaMeta(outDir: string, meta: SuryaOcrMeta): Promise<void> {
+    await fsp.mkdir(outDir, { recursive: true });
+    await fsp.writeFile(path.join(outDir, 'meta.json'), JSON.stringify(meta), 'utf8');
+}
+
+/**
+ * Write a single page's ObservationPage to JSON file.
+ */
+async function writePageJson(pagesDir: string, page: ObservationPage): Promise<void> {
+    const outPath = path.join(pagesDir, `${page.page}.json`);
+    await fsp.writeFile(outPath, JSON.stringify(page), 'utf8');
+}
+
+/**
+ * Split surya OCR output into per-page JSON files matching macOCR format.
+ * Creates pages/ directory with 1.json, 2.json, etc.
+ */
+export async function splitSuryaOcrToPages({ outDir, pages }: SplitSuryaOcrOptions): Promise<SuryaOcrMeta> {
+    const pagesDir = path.join(outDir, 'pages');
+    await fsp.mkdir(pagesDir, { recursive: true });
+
+    // Write per-page JSON (converting from surya format to macOCR format)
+    for (const suryaPage of pages) {
+        const observationPage = convertSuryaToObservationPage(suryaPage);
+        await writePageJson(pagesDir, observationPage);
+    }
+
+    const meta = buildSuryaMeta(pages);
+    await writeSuryaMeta(outDir, meta);
+    return meta;
+}


### PR DESCRIPTION
# Add Surya OCR Engine Support

Add Surya OCR as a second OCR engine that runs in parallel with macOCR, with independent SSE progress streaming and side-by-side result rendering.

## User Review Required

> [!IMPORTANT]
> **GPU Configuration**: Surya supports MPS (Metal Performance Shaders) on M-series Macs. Plan uses `TORCH_DEVICE=mps` for GPU acceleration on your M4 Max. Fall back to `cpu` if issues arise.

> [!IMPORTANT]
> **Virtual Environment**: Surya runs in `~/surya-env`. The implementation will spawn commands using `source ~/surya-env/bin/activate && surya_ocr ...` pattern.

## Proposed Changes

### Surya Types

#### [NEW] [suryaOcr.ts](src/lib/suryaOcr.ts)

Define TypeScript types matching the filtered surya.json output:

```typescript
export type SuryaTextLine = {
    bbox: [number, number, number, number];
    text: string;
};

export type SuryaPageOcrResult = {
    image_bbox: [number, number, number, number];
    page: number;
    text_lines: SuryaTextLine[];
};

// Record<filename, SuryaPageOcrResult[]>
export type SuryaOcrOutput = Record<string, SuryaPageOcrResult[]>;
```

---

### Surya OCR Runner

#### [NEW] [runSuryaOcr.ts](src/server/ocr/runSuryaOcr.ts)

Similar structure to [runMacOcr.ts](src/server/ocr/runMacOcr.ts):

1. **Spawn surya_ocr** with:
   - `TORCH_DEVICE=mps` environment (GPU on M4 Max)
   - `--disable_math` flag
   - `--output_dir` pointing to job's surya output directory
   - Input cropped PDF path

2. **Parse progress** from stderr with patterns:
   - `Detecting bboxes:\s+(\d+)%` → bounding box detection phase
   - `Recognizing Text:\s+(\d+)%` (or `\d+/\d+` format) → text recognition phase

3. **Emit SSE events** via new surya-specific event bus functions

4. **Post-process results.json** with jq-like filtering (implemented in JS):
   - Strip `chars`, `confidence`, `polygon`, `words`, `original_text_good` fields
   - Keep only `image_bbox`, [page](src/server/ocr/splitMacOcr.ts#9-15), and simplified `text_lines`

5. **Split to pages** similar to [splitMacOcr.ts](src/server/ocr/splitMacOcr.ts)

---

#### [NEW] [splitSuryaOcr.ts](src/server/ocr/splitSuryaOcr.ts)

Convert surya output to per-page JSON files matching the [ObservationPage](src/lib/macOcr.ts#9-10) format used by macOCR for unified page rendering:

```typescript
export function convertSuryaToObservationPage(suryaPage: SuryaPageOcrResult): ObservationPage;
export async function splitSuryaOcrToPages(options: SplitSuryaOcrOptions): Promise<OcrMeta>;
```

---

### OCR Paths Extension

#### [MODIFY] [ocrPaths.ts](src/server/ocr/ocrPaths.ts)

Add surya-specific paths:

```diff
+export function jobSuryaOcrDir(jobId: string): string {
+    return path.join(jobDir(jobId), 'surya');
+}
+
+export function jobSuryaResultsJsonPath(jobId: string): string {
+    return path.join(jobSuryaOcrDir(jobId), 'results.json');
+}
+
+export function jobSuryaOcrJsonPath(jobId: string): string {
+    return path.join(jobSuryaOcrDir(jobId), 'surya.json');
+}
+
+export function jobSuryaMetaPath(jobId: string): string {
+    return path.join(jobSuryaOcrDir(jobId), 'meta.json');
+}
+
+export function jobSuryaPagesDir(jobId: string): string {
+    return path.join(jobSuryaOcrDir(jobId), 'pages');
+}
```

---

### Event Bus Extension

#### [MODIFY] [ocrEventBus.ts](src/server/ocr/ocrEventBus.ts)

Add surya-specific event functions:

```diff
+export function suryaBus(jobId: string): OcrEventBus { ... }
+export function getLastSuryaProgress(jobId: string): OcrProgressEvent | null { ... }
+export function emitSuryaProgress(jobId: string, ev: OcrProgressEvent): void { ... }
+export function emitSuryaComplete(jobId: string): void { ... }
+export function emitSuryaError(jobId: string, message: string): void { ... }
```

---

### Job Store Extension

#### [MODIFY] [jobStore.ts](src/server/jobs/jobStore.ts)

Add surya OCR status tracking:

```diff
 export type Job = {
     // ... existing fields
     ocr?: JobOcr;
+    suryaOcr?: JobOcr;
     sourceUrl?: string;
 };
```

---

### API Routes

#### [MODIFY] [route.ts](src/app/api/jobs/[jobId]/ocr/route.ts)

Add `?engine=macOCR|surya|both` query param:
- `macOCR` (default): run only macOCR (current behavior)
- `surya`: run only surya
- `both`: run both in parallel using `Promise.all`

GET endpoint returns status for both engines when `both` is selected.

---

#### [NEW] [route.ts](src/app/api/jobs/[jobId]/surya/route.ts)

Dedicated surya OCR route following same pattern as [/ocr/route.ts](src/app/api/jobs/%5BjobId%5D/ocr/route.ts).

---

#### [NEW] [route.ts](src/app/api/jobs/[jobId]/surya/events/route.ts)

SSE endpoint for surya progress events, using `suryaBus(jobId)`.

---

#### [NEW] [route.ts](src/app/api/jobs/[jobId]/surya/pages/[page]/route.ts)

Per-page JSON endpoint for surya results.

---

### Frontend Updates

#### [MODIFY] [PageOcrTable.tsx](src/components/PageOcrTable.tsx)

1. **Dual SSE connections**: Connect to both `/ocr/events` and `/surya/events`
2. **Dual progress tracking**: Track `ocrProgress`, `suryaProgress`, `ocrStatus`, `suryaStatus`
3. **Dual text fetching**: Fetch from both `/ocr/pages/:page` and `/surya/pages/:page`
4. **Side-by-side columns**: Add fourth column for Surya OCR text

Table structure:
```
| Page | Image | macOCR Text | Surya Text |
```

5. **Run button options**: "Run macOCR", "Run Surya", "Run Both"

---

## Verification Plan

### Automated Tests

#### Unit Tests for `runSuryaOcr.ts`

Run with: `bun test src/server/ocr/runSuryaOcr.test.ts`

Tests to add:
- Should spawn surya_ocr with correct args and environment
- Should parse progress from detecting bboxes phase
- Should parse progress from recognizing text phase
- Should filter results.json and write surya.json
- Should emit progress/complete/error events
- Should handle failures gracefully
- Should not spawn twice if already running

#### Unit Tests for `splitSuryaOcr.ts`

Run with: `bun test src/server/ocr/splitSuryaOcr.test.ts`

Tests to add:
- Should convert SuryaPageOcrResult to ObservationPage format
- Should write per-page JSON files
- Should write meta.json with correct totalPages

#### Existing Tests

Run all OCR tests: `bun test src/server/ocr/`

Ensure existing macOCR tests still pass after modifications.

### Manual Verification

1. **Start dev server**: `bun run dev`
2. **Upload a PDF** via the UI
3. **Set crop** (optional)
4. **Click "Run Both"** button
5. **Verify SSE progress**:
   - Both macOCR and Surya progress should stream in UI
   - Progress bars or text should show "Detecting bboxes X%" and "Recognizing Text Y%"
6. **Verify results**:
   - Both columns should populate with Arabic text
   - Surya column should be adjacent to macOCR column
7. **Verify parallel execution**:
   - Both processes should run concurrently (check logs for overlapping timestamps)


# Surya OCR Integration Walkthrough

## Summary

Added Surya OCR as a second OCR engine alongside macOCR, enabling parallel execution with independent SSE progress streaming and side-by-side result comparison in the UI.

## Changes Made

### New Files

| File | Purpose |
|------|---------|
| [suryaOcr.ts](src/lib/suryaOcr.ts) | TypeScript types for Surya JSON output |
| [splitSuryaOcr.ts](src/server/ocr/splitSuryaOcr.ts) | Filters raw output, converts to macOCR format, splits to pages |
| [runSuryaOcr.ts](src/server/ocr/runSuryaOcr.ts) | Main runner with MPS/CPU fallback, venv activation |
| [surya/route.ts](src/app/api/jobs/%5BjobId%5D/surya/route.ts) | POST to start Surya, GET for status |
| [surya/events/route.ts](src/app/api/jobs/%5BjobId%5D/surya/events/route.ts) | SSE endpoint for progress streaming |
| [surya/pages/[page]/route.ts](src/app/api/jobs/%5BjobId%5D/surya/pages/%5Bpage%5D/route.ts) | Per-page JSON results |
| [splitSuryaOcr.test.ts](src/server/ocr/splitSuryaOcr.test.ts) | 7 unit tests |
| [runSuryaOcr.test.ts](src/server/ocr/runSuryaOcr.test.ts) | 10 unit tests |

### Modified Files

| File | Changes |
|------|---------|
| [ocrPaths.ts](src/server/ocr/ocrPaths.ts) | Added surya path functions |
| [ocrEventBus.ts](src/server/ocr/ocrEventBus.ts) | Added [suryaBus](src/server/ocr/ocrEventBus.ts#95-105), surya emit functions, `phase` field |
| [jobStore.ts](src/server/jobs/jobStore.ts) | Added `suryaOcr` field to Job type |
| [PageOcrTable.tsx](src/components/PageOcrTable.tsx) | Engine dropdown, dual SSE connections, side-by-side columns |
| [AGENTS.md](AGENTS.md) | Updated with Surya documentation |

## Key Features

1. **Engine Selection**: Dropdown with options: "Both Engines", "macOCR Only", "Surya Only"
2. **Parallel Execution**: Both engines run via `Promise.all` when "Both" is selected
3. **GPU Acceleration**: Uses `TORCH_DEVICE=mps` for M4 Max, falls back to `cpu` if MPS fails
4. **Virtual Environment**: Spawns surya within `~/surya-env` activation
5. **Progress Streaming**: Independent SSE streams for each engine with phase detection

## Test Results

```
134 pass, 0 fail
328 expect() calls
Ran 134 tests across 28 files
```

New surya tests: 17 (7 for splitSuryaOcr + 10 for runSuryaOcr)

## Usage

1. Start dev server: `bun run dev`
2. Upload a PDF
3. Set crop (optional)
4. Select engine from dropdown
5. Click "Run OCR"
6. Watch progress for both engines
7. Compare results side-by-side


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-engine OCR (macOCR and Surya) with selectable/parallel runs and per-page results.
  * Real-time SSE progress streams per engine and per-job, plus per-page text endpoints.
  * Persistent global crop applied to pages, URL-based uploads, deduplication by hash, and recoverable job snapshots.
  * Side-by-side page image and OCR text viewer; MPS→CPU fallback for Surya.

* **Documentation**
  * Reorganized README and setup guidance for optional OCR toolchain.

* **Tests**
  * New Surya OCR integration and split/output tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->