### PR TITLE
Add kokokor support and running macOCR remotely

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ### Requirements
 
-- **Bun**: `>=1.3.5`
+- **Bun**: `>=1.3.9`
 - **Node.js**: `>=24`
 - **Poppler** (PDF rendering): `pdfinfo`, `pdftocairo`
 - **macOCR** (Arabic OCR): macOS Vision-based CLI tool
@@ -90,6 +90,11 @@ bun test
 - `GET /api/jobs/:jobId/ocr`: Check OCR status.
 - `GET /api/jobs/:jobId/ocr/events`: OCR progress stream (SSE).
 - `GET /api/jobs/:jobId/ocr/pages/:page`: Fetch extracted text for a specific page.
+- `GET /api/jobs/:jobId/ocr/file`: Fetch full OCR JSON file.
+
+### UploadThing
+- `POST /api/uploadthing`: UploadThing route handler.
+- `POST /api/uploadthing/ingest`: Convert UploadThing file key into a swissawa job.
 
 ### OCR (Surya)
 - `POST /api/jobs/:jobId/surya`: Trigger Surya OCR process.
@@ -104,6 +109,135 @@ bun test
 - QA/diffing tools for ground truth verification.
 
 See `AGENTS.md` for deep-dive architecture notes and development pitfalls.
+
+## Remote OCR (PAT-first)
+
+This repo supports a cloud-offloaded macOCR backend using GitHub Actions.
+
+### Environment variables
+
+Current runtime auth in this repo is **PAT-first** (`SWISSAWA_GH_PAT`).  
+The auth layer is abstracted so you can migrate to GitHub App tokens later without changing provider call sites.
+
+Use this as a copy/paste baseline:
+
+```bash
+# OCR backend mode
+SWISSAWA_MAC_OCR_BACKEND=local
+
+# Remote OCR (required only when SWISSAWA_MAC_OCR_BACKEND=github_actions)
+SWISSAWA_GH_PAT=
+SWISSAWA_GH_OCR_REPO=ragaeeb/macOCR
+SWISSAWA_GH_OCR_WORKFLOW=ocr-remote.yml
+SWISSAWA_GH_OCR_REF=main
+SWISSAWA_GH_OCR_POLL_INTERVAL_MS=5000
+SWISSAWA_GH_OCR_TIMEOUT_MS=900000
+
+# Upload mode
+UPLOADTHING_TOKEN=
+NEXT_PUBLIC_SWISSAWA_UPLOAD_MODE=direct
+```
+
+### How to get each value
+
+- `SWISSAWA_MAC_OCR_BACKEND`:
+  - `local` keeps classic DX (local upload + local macOCR).
+  - `github_actions` offloads macOCR to GitHub Actions.
+- `SWISSAWA_GH_PAT`:
+  - Create a token in GitHub settings.
+  - Fine-grained PAT (preferred): grant repository **Actions: Read and write** on the OCR repo.
+  - If using classic PAT with private repos, `repo` scope works.
+- `SWISSAWA_GH_OCR_REPO`:
+  - `<owner>/<repo>` of the remote OCR repo (for example `ragaeeb/macOCR`).
+- `SWISSAWA_GH_OCR_WORKFLOW`:
+  - Workflow file name in that repo (for example `ocr-remote.yml`).
+- `SWISSAWA_GH_OCR_REF`:
+  - Git ref to dispatch against (usually `main`).
+- `SWISSAWA_GH_OCR_POLL_INTERVAL_MS`:
+  - How often swissawa polls run status. Start with `5000`.
+- `SWISSAWA_GH_OCR_TIMEOUT_MS`:
+  - Max wait before timeout. Default `900000` (15 minutes).
+- `UPLOADTHING_TOKEN`:
+  - In UploadThing dashboard, open your app and copy the token from **API Keys**.
+  - For v7 this is a single token carrying app info + secret.
+- `NEXT_PUBLIC_SWISSAWA_UPLOAD_MODE`:
+  - `direct` uses current server upload route.
+  - `uploadthing` uses UploadThing client upload + `/api/uploadthing/ingest`.
+
+### PAT setup (current runtime path)
+
+1. Open GitHub Settings -> Developer settings -> Personal access tokens.
+2. Create a fine-grained token (recommended) scoped to your OCR repo.
+3. Grant repository permission: `Actions: Read and write`.
+4. Save token as `SWISSAWA_GH_PAT` in your environment.
+5. Set `SWISSAWA_MAC_OCR_BACKEND=github_actions` and test `POST /api/jobs/:jobId/ocr`.
+
+### GitHub App setup (recommended for production, migration-ready)
+
+The app code currently uses PAT auth at runtime.  
+Use this section to prepare migration values and install the app with correct permissions.
+
+1. Create app:
+   - GitHub -> Settings -> Developer settings -> GitHub Apps -> New GitHub App.
+   - Set name and homepage URL.
+   - Webhook: keep **inactive** for polling-only MVP.
+   - Visibility: choose private ("Only on this account") unless you need multi-account installs.
+2. Configure repository permissions (minimum for this OCR flow):
+   - `Actions: Read and write` (dispatch workflows + read runs/artifacts).
+   - `Contents: Read` (repo metadata/workflow context reads).
+   - `Metadata: Read` is included automatically.
+3. Install app:
+   - Open the app settings page -> `Install App`.
+   - Install on the account/org owning the OCR repo.
+   - Choose target repo(s), including your OCR repo.
+4. Generate private key:
+   - In app settings, under `Private keys`, click `Generate a private key`.
+   - Download and store it securely (GitHub only stores the public portion).
+5. Record IDs:
+   - `App ID`: on the app settings page.
+   - `Installation ID`: get via API (`GET /repos/{owner}/{repo}/installation`) or from app installation context.
+6. Keep migration env names ready (planned, not active in runtime yet):
+   - `SWISSAWA_GH_APP_ID`
+   - `SWISSAWA_GH_APP_PRIVATE_KEY`
+   - `SWISSAWA_GH_APP_INSTALLATION_ID`
+
+### Local DX defaults
+
+- Keep local upload + local macOCR:
+  - `SWISSAWA_MAC_OCR_BACKEND=local`
+  - `NEXT_PUBLIC_SWISSAWA_UPLOAD_MODE=direct`
+
+### Deployed cloud mode
+
+- Use UploadThing ingest + GitHub Actions OCR:
+  - `SWISSAWA_MAC_OCR_BACKEND=github_actions`
+  - `NEXT_PUBLIC_SWISSAWA_UPLOAD_MODE=uploadthing`
+
+Auth decision and migration notes to GitHub App are documented in:
+`docs/decisions/0001-remote-ocr-auth.md`.
+
+### Reference docs (verified)
+
+- GitHub workflow dispatch endpoint and required permissions:
+  - <https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event>
+- GitHub workflow runs:
+  - <https://docs.github.com/en/rest/actions/workflow-runs>
+- GitHub artifacts:
+  - <https://docs.github.com/en/rest/actions/artifacts>
+- Registering a GitHub App:
+  - <https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app>
+- Choosing GitHub App permissions:
+  - <https://docs.github.com/apps/creating-github-apps/setting-up-a-github-app/choosing-permissions-for-a-github-app>
+- Installing your own GitHub App:
+  - <https://docs.github.com/en/developers/apps/managing-github-apps/installing-github-apps>
+- Managing GitHub App private keys:
+  - <https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps>
+- Generating installation access tokens:
+  - <https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app>
+- UploadThing v7 token model:
+  - <https://docs.uploadthing.com/v7>
+- UploadThing docs home:
+  - <https://docs.uploadthing.com/>
 
 ## License
 

--- a/bun.lock
+++ b/bun.lock
@@ -62,23 +62,23 @@
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.3.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.14", "@biomejs/cli-darwin-x64": "2.3.14", "@biomejs/cli-linux-arm64": "2.3.14", "@biomejs/cli-linux-arm64-musl": "2.3.14", "@biomejs/cli-linux-x64": "2.3.14", "@biomejs/cli-linux-x64-musl": "2.3.14", "@biomejs/cli-win32-arm64": "2.3.14", "@biomejs/cli-win32-x64": "2.3.14" }, "bin": { "biome": "bin/biome" } }, "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.3", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.3", "@biomejs/cli-darwin-x64": "2.4.3", "@biomejs/cli-linux-arm64": "2.4.3", "@biomejs/cli-linux-arm64-musl": "2.4.3", "@biomejs/cli-linux-x64": "2.4.3", "@biomejs/cli-linux-x64-musl": "2.4.3", "@biomejs/cli-win32-arm64": "2.4.3", "@biomejs/cli-win32-x64": "2.4.3" }, "bin": { "biome": "bin/biome" } }, "sha512-cBrjf6PNF6yfL8+kcNl85AjiK2YHNsbU0EvDOwiZjBPbMbQ5QcgVGFpjD0O52p8nec5O8NYw7PKw3xUR7fPAkQ=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UJGPpvWJMkLxSRtpCAKfKh41Q4JJXisvxZL8ChN1eNW3m/WlPFJ6EFDCE7YfUb4XS8ZFi3C1dFpxUJ0Ety5n+A=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-eOafSFlI/CF4id2tlwq9CVHgeEqvTL5SrhWff6ZORp6S3NL65zdsR3ugybItkgF8Pf4D9GSgtbB6sE3UNgOM9w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-PNkLNQG6RLo8lG7QoWe/hhnMxJIt1tEimoXpGQjwS/dkdNiKBLPv4RpeQl8o3s1OKI3ZOR5XPiYtmbGGHAOnLA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-V2+av4ilbWcBMNufTtMMXVW00nPwyIjI5qf7n9wSvUaZ+tt0EvMGk46g9sAFDJBEDOzSyoRXiSP6pCvKTOEbPA=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-0m+O0x9FgK99FAwDK+fiDtjs2wnqq7bvfj17KJVeCkTwT/liI+Q9njJG7lwXK0iSJVXeFNRIxukpVI3SifMYAA=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-LInRbXhYujtL3sH2TMCH/UBwJZsoGwfQjBrMfl84CD4hL/41C/EU5mldqf1yoFpsI0iPWuU83U+nB2TUUypWeg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-QuFzvsGo8BA4Xm7jGX5idkw6BqFblcCPySMTvq0AhGYnhUej5VJIDJbmTKfHqwjHepZiC4fA+T5i6wmiZolZNw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.3", "", { "os": "linux", "cpu": "x64" }, "sha512-NVqh0saIU0u5OfOp/0jFdlKRE59+XyMvWmtx0f6Nm/2OpdxBl04coRIftBbY9d1gfu+23JVv4CItAqPYrjYh5w=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.3", "", { "os": "linux", "cpu": "x64" }, "sha512-qEc0OCpj/uytruQ4wLM0yWNJLZy0Up8H1Er5MW3SrstqM6J2d4XqdNA86xzCy8MQCHpoVZ3lFye3GBlIL4/ljw=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gRO96vrIARilv/Cp2ZnmNNL5LSZg3RO75GPp13hsLO3N4YVpE7saaMDp2bcyV48y2N2Pbit1brkGVGta0yd6VQ=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.3", "", { "os": "win32", "cpu": "x64" }, "sha512-vSm/vOJe06pf14aGHfHl3Ar91Nlx4YYmohElDJ+17UbRwe99n987S/MhAlQOkONqf1utJor04ChkCPmKb8SWdw=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
@@ -276,41 +276,41 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
-    "@tailwindcss/node": ["@tailwindcss/node@4.1.18", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.18" } }, "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ=="],
+    "@tailwindcss/node": ["@tailwindcss/node@4.2.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.0" } }, "sha512-Yv+fn/o2OmL5fh/Ir62VXItdShnUxfpkMA4Y7jdeC8O81WPB8Kf6TT6GSHvnqgSwDzlB5iT7kDpeXxLsUS0T6Q=="],
 
-    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.1.18", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.1.18", "@tailwindcss/oxide-darwin-arm64": "4.1.18", "@tailwindcss/oxide-darwin-x64": "4.1.18", "@tailwindcss/oxide-freebsd-x64": "4.1.18", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18", "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18", "@tailwindcss/oxide-linux-arm64-musl": "4.1.18", "@tailwindcss/oxide-linux-x64-gnu": "4.1.18", "@tailwindcss/oxide-linux-x64-musl": "4.1.18", "@tailwindcss/oxide-wasm32-wasi": "4.1.18", "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18", "@tailwindcss/oxide-win32-x64-msvc": "4.1.18" } }, "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A=="],
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.0", "@tailwindcss/oxide-darwin-arm64": "4.2.0", "@tailwindcss/oxide-darwin-x64": "4.2.0", "@tailwindcss/oxide-freebsd-x64": "4.2.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.0", "@tailwindcss/oxide-linux-arm64-musl": "4.2.0", "@tailwindcss/oxide-linux-x64-gnu": "4.2.0", "@tailwindcss/oxide-linux-x64-musl": "4.2.0", "@tailwindcss/oxide-wasm32-wasi": "4.2.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.0", "@tailwindcss/oxide-win32-x64-msvc": "4.2.0" } }, "sha512-AZqQzADaj742oqn2xjl5JbIOzZB/DGCYF/7bpvhA8KvjUj9HJkag6bBuwZvH1ps6dfgxNHyuJVlzSr2VpMgdTQ=="],
 
-    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.1.18", "", { "os": "android", "cpu": "arm64" }, "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q=="],
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.2.0", "", { "os": "android", "cpu": "arm64" }, "sha512-F0QkHAVaW/JNBWl4CEKWdZ9PMb0khw5DCELAOnu+RtjAfx5Zgw+gqCHFvqg3AirU1IAd181fwOtJQ5I8Yx5wtw=="],
 
-    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.1.18", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A=="],
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.2.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-I0QylkXsBsJMZ4nkUNSR04p6+UptjcwhcVo3Zu828ikiEqHjVmQL9RuQ6uT/cVIiKpvtVA25msu/eRV97JeNSA=="],
 
-    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.1.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw=="],
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.2.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-6TmQIn4p09PBrmnkvbYQ0wbZhLtbaksCDx7Y7R3FYYx0yxNA7xg5KP7dowmQ3d2JVdabIHvs3Hx4K3d5uCf8xg=="],
 
-    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.1.18", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA=="],
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.2.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-qBudxDvAa2QwGlq9y7VIzhTvp2mLJ6nD/G8/tI70DCDoneaUeLWBJaPcbfzqRIWraj+o969aDQKvKW9dvkUizw=="],
 
-    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18", "", { "os": "linux", "cpu": "arm" }, "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA=="],
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.2.0", "", { "os": "linux", "cpu": "arm" }, "sha512-7XKkitpy5NIjFZNUQPeUyNJNJn1CJeV7rmMR+exHfTuOsg8rxIO9eNV5TSEnqRcaOK77zQpsyUkBWmPy8FgdSg=="],
 
-    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.1.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw=="],
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Mff5a5Q3WoQR01pGU1gr29hHM1N93xYrKkGXfPw/aRtK4bOc331Ho4Tgfsm5WDGvpevqMpdlkCojT3qlCQbCpA=="],
 
-    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.1.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg=="],
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-XKcSStleEVnbH6W/9DHzZv1YhjE4eSS6zOu2eRtYAIh7aV4o3vIBs+t/B15xlqoxt6ef/0uiqJVB6hkHjWD/0A=="],
 
-    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.1.18", "", { "os": "linux", "cpu": "x64" }, "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g=="],
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA=="],
 
-    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.1.18", "", { "os": "linux", "cpu": "x64" }, "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ=="],
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-lKUaygq4G7sWkhQbfdRRBkaq4LY39IriqBQ+Gk6l5nKq6Ay2M2ZZb1tlIyRNgZKS8cbErTwuYSor0IIULC0SHw=="],
 
-    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.1.18", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.0", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.4.0" }, "cpu": "none" }, "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA=="],
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.2.0", "", { "dependencies": { "@emnapi/core": "^1.8.1", "@emnapi/runtime": "^1.8.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.1", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-xuDjhAsFdUuFP5W9Ze4k/o4AskUtI8bcAGU4puTYprr89QaYFmhYOPfP+d1pH+k9ets6RoE23BXZM1X1jJqoyw=="],
 
-    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.1.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA=="],
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-2UU/15y1sWDEDNJXxEIrfWKC2Yb4YgIW5Xz2fKFqGzFWfoMHWFlfa1EJlGO2Xzjkq/tvSarh9ZTjvbxqWvLLXA=="],
 
-    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.1.18", "", { "os": "win32", "cpu": "x64" }, "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q=="],
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.0", "", { "os": "win32", "cpu": "x64" }, "sha512-CrFadmFoc+z76EV6LPG1jx6XceDsaCG3lFhyLNo/bV9ByPrE+FnBPckXQVP4XRkN76h3Fjt/a+5Er/oA/nCBvQ=="],
 
-    "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.18", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.18", "@tailwindcss/oxide": "4.1.18", "postcss": "^8.4.41", "tailwindcss": "4.1.18" } }, "sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g=="],
+    "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.0", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.0", "@tailwindcss/oxide": "4.2.0", "postcss": "^8.5.6", "tailwindcss": "4.2.0" } }, "sha512-u6YBacGpOm/ixPfKqfgrJEjMfrYmPD7gEFRoygS/hnQaRtV0VCBdpkx5Ouw9pnaLRwwlgGCuJw8xLpaR0hOrQg=="],
 
     "@types/adm-zip": ["@types/adm-zip@0.5.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
-    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+    "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 
@@ -426,7 +426,7 @@
 
     "emojilib": ["emojilib@2.4.0", "", {}, "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.18.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q=="],
+    "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
     "env-ci": ["env-ci@11.2.0", "", { "dependencies": { "execa": "^8.0.0", "java-properties": "^1.0.2" } }, "sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA=="],
 
@@ -544,31 +544,31 @@
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
-    "kokokor": ["kokokor@2.1.0", "", {}, "sha512-dBL9eJH5ccmUZdNWOB20V2RsMaOQQLf2t5uifoNAMT+VyaxgI5jLFBE6GdlmCTFfexk4/uAWjAyMAASBOFqV3g=="],
+    "kokokor": ["kokokor@2.2.0", "", {}, "sha512-2PQ5zSusKdIlgEaMFmCectaPL3Jt82gPYRrHVDV89hddaegfRkrZlrf8Ew61qPXqPvpYXt9Tmlmgyq7NC42c/A=="],
 
-    "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
+    "lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
 
-    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.30.2", "", { "os": "android", "cpu": "arm64" }, "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A=="],
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.31.1", "", { "os": "android", "cpu": "arm64" }, "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg=="],
 
-    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.30.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA=="],
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.31.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg=="],
 
-    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.30.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ=="],
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.31.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA=="],
 
-    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.30.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA=="],
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.31.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A=="],
 
-    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.30.2", "", { "os": "linux", "cpu": "arm" }, "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA=="],
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.31.1", "", { "os": "linux", "cpu": "arm" }, "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g=="],
 
-    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.30.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A=="],
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg=="],
 
-    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.30.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA=="],
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg=="],
 
-    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.30.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w=="],
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA=="],
 
-    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.30.2", "", { "os": "linux", "cpu": "x64" }, "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA=="],
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA=="],
 
-    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.30.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ=="],
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.31.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w=="],
 
-    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw=="],
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
@@ -592,7 +592,7 @@
 
     "lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
-    "lucide-react": ["lucide-react@0.563.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA=="],
+    "lucide-react": ["lucide-react@0.575.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -796,9 +796,9 @@
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
-    "tailwind-merge": ["tailwind-merge@3.4.0", "", {}, "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g=="],
+    "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
-    "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
+    "tailwindcss": ["tailwindcss@4.2.0", "", {}, "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
@@ -834,7 +834,7 @@
 
     "undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
 
-    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "unicode-emoji-modifier-base": ["unicode-emoji-modifier-base@1.0.0", "", {}, "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="],
 
@@ -904,9 +904,9 @@
 
     "@swc/helpers/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
@@ -916,7 +916,11 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@types/adm-zip/@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+
     "aria-hidden/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "bun-types/@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -1307,6 +1311,14 @@
     "@semantic-release/release-notes-generator/read-package-up/read-pkg": ["read-pkg@9.0.1", "", { "dependencies": { "@types/normalize-package-data": "^2.4.3", "normalize-package-data": "^6.0.0", "parse-json": "^8.0.0", "type-fest": "^4.6.0", "unicorn-magic": "^0.1.0" } }, "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA=="],
 
     "@semantic-release/release-notes-generator/read-package-up/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
+
+    "@types/adm-zip/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "cli-highlight/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,8 +9,10 @@
         "@radix-ui/react-dialog": "latest",
         "@radix-ui/react-label": "latest",
         "@radix-ui/react-slot": "latest",
+        "adm-zip": "latest",
         "class-variance-authority": "latest",
         "clsx": "latest",
+        "kokokor": "latest",
         "lucide-react": "latest",
         "next": "latest",
         "pdf-lib": "latest",
@@ -18,12 +20,14 @@
         "react-dom": "latest",
         "react-image-crop": "latest",
         "tailwind-merge": "latest",
+        "uploadthing": "latest",
       },
       "devDependencies": {
         "@biomejs/biome": "latest",
         "@semantic-release/changelog": "latest",
         "@semantic-release/git": "latest",
         "@tailwindcss/postcss": "latest",
+        "@types/adm-zip": "latest",
         "@types/bun": "latest",
         "@types/node": "latest",
         "@types/react": "latest",
@@ -58,25 +62,27 @@
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.3.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.11", "@biomejs/cli-darwin-x64": "2.3.11", "@biomejs/cli-linux-arm64": "2.3.11", "@biomejs/cli-linux-arm64-musl": "2.3.11", "@biomejs/cli-linux-x64": "2.3.11", "@biomejs/cli-linux-x64-musl": "2.3.11", "@biomejs/cli-win32-arm64": "2.3.11", "@biomejs/cli-win32-x64": "2.3.11" }, "bin": { "biome": "bin/biome" } }, "sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ=="],
+    "@biomejs/biome": ["@biomejs/biome@2.3.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.14", "@biomejs/cli-darwin-x64": "2.3.14", "@biomejs/cli-linux-arm64": "2.3.14", "@biomejs/cli-linux-arm64-musl": "2.3.14", "@biomejs/cli-linux-x64": "2.3.14", "@biomejs/cli-linux-x64-musl": "2.3.14", "@biomejs/cli-win32-arm64": "2.3.14", "@biomejs/cli-win32-x64": "2.3.14" }, "bin": { "biome": "bin/biome" } }, "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/uXXkBcPKVQY7rc9Ys2CrlirBJYbpESEDme7RKiBD6MmqR2w3j0+ZZXRIL2xiaNPsIMMNhP1YnA+jRRxoOAFrA=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UJGPpvWJMkLxSRtpCAKfKh41Q4JJXisvxZL8ChN1eNW3m/WlPFJ6EFDCE7YfUb4XS8ZFi3C1dFpxUJ0Ety5n+A=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-fh7nnvbweDPm2xEmFjfmq7zSUiox88plgdHF9OIW4i99WnXrAC3o2P3ag9judoUMv8FCSUnlwJCM1B64nO5Fbg=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-PNkLNQG6RLo8lG7QoWe/hhnMxJIt1tEimoXpGQjwS/dkdNiKBLPv4RpeQl8o3s1OKI3ZOR5XPiYtmbGGHAOnLA=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-XPSQ+XIPZMLaZ6zveQdwNjbX+QdROEd1zPgMwD47zvHV+tCGB88VH+aynyGxAHdzL+Tm/+DtKST5SECs4iwCLg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-LInRbXhYujtL3sH2TMCH/UBwJZsoGwfQjBrMfl84CD4hL/41C/EU5mldqf1yoFpsI0iPWuU83U+nB2TUUypWeg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.11", "", { "os": "win32", "cpu": "x64" }, "sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
+
+    "@effect/platform": ["@effect/platform@0.90.3", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.33.0", "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.17.7" } }, "sha512-XvQ37yzWQKih4Du2CYladd1i/MzqtgkTPNCaN6Ku6No4CK83hDtXIV/rP03nEoBg2R3Pqgz6gGWmE2id2G81HA=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
 
@@ -146,23 +152,35 @@
 
     "@mjackson/multipart-parser": ["@mjackson/multipart-parser@0.10.1", "", { "dependencies": { "@mjackson/headers": "^0.11.1" } }, "sha512-cHMD6+ErH/DrEfC0N6Ru/+1eAdavxdV0C35PzSb5/SD7z3XoaDMc16xPJcb8CahWjSpqHY+Too9sAb6/UNuq7A=="],
 
-    "@next/env": ["@next/env@16.1.1", "", {}, "sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA=="],
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.1.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA=="],
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.1.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw=="],
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ=="],
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg=="],
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ=="],
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA=="],
+    "@next/env": ["@next/env@16.1.6", "", {}, "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.1.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.1.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.1.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ=="],
+
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.1.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw=="],
+
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.1.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ=="],
+
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ=="],
+
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg=="],
+
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.1.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw=="],
+
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A=="],
 
     "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
 
@@ -185,6 +203,8 @@
     "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
 
     "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.39.0", "", {}, "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg=="],
 
     "@pdf-lib/standard-fonts": ["@pdf-lib/standard-fonts@1.0.0", "", { "dependencies": { "pako": "^1.0.6" } }, "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA=="],
 
@@ -252,6 +272,8 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.0.0-beta.4", "", {}, "sha512-d3IxtzLo7P1oZ8s8YNvxzBUXRXojSut8pbPrTYtzsc5sn4+53jVqbk66pQerSZbZSJZQux6LkclB/+8IDordHg=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.18", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.18" } }, "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ=="],
@@ -284,15 +306,23 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.18", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.18", "@tailwindcss/oxide": "4.1.18", "postcss": "^8.4.41", "tailwindcss": "4.1.18" } }, "sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g=="],
 
-    "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+    "@types/adm-zip": ["@types/adm-zip@0.5.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw=="],
 
-    "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
+    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 
-    "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@uploadthing/mime-types": ["@uploadthing/mime-types@0.3.6", "", {}, "sha512-t3tTzgwFV9+1D7lNDYc7Lr7kBwotHaX0ZsvoCGe7xGnXKo9z0jG2Sjl/msll12FeoLj77nyhsxevXyGpQDBvLg=="],
+
+    "@uploadthing/shared": ["@uploadthing/shared@7.1.10", "", { "dependencies": { "@uploadthing/mime-types": "0.3.6", "effect": "3.17.7", "sqids": "^0.3.0" } }, "sha512-R/XSA3SfCVnLIzFpXyGaKPfbwlYlWYSTuGjTFHuJhdAomuBuhopAHLh2Ois5fJibAHzi02uP1QCKbgTAdmArqg=="],
+
+    "adm-zip": ["adm-zip@0.5.16", "", {}, "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -324,7 +354,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -390,6 +420,8 @@
 
     "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
 
+    "effect": ["effect@3.17.7", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-dpt0ONUn3zzAuul6k4nC/coTTw27AL5nhkORXgTi6NfMPzqWYa1M05oKmOMTxpVSTKepqXVcW9vIwkuaaqx9zA=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "emojilib": ["emojilib@2.4.0", "", {}, "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="],
@@ -410,6 +442,8 @@
 
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
     "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -417,6 +451,8 @@
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
     "find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
 
@@ -508,6 +544,8 @@
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
+    "kokokor": ["kokokor@2.1.0", "", {}, "sha512-dBL9eJH5ccmUZdNWOB20V2RsMaOQQLf2t5uifoNAMT+VyaxgI5jLFBE6GdlmCTFfexk4/uAWjAyMAASBOFqV3g=="],
+
     "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
 
     "lightningcss-android-arm64": ["lightningcss-android-arm64@1.30.2", "", { "os": "android", "cpu": "arm64" }, "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A=="],
@@ -554,7 +592,7 @@
 
     "lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
-    "lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
+    "lucide-react": ["lucide-react@0.563.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -578,6 +616,12 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "msgpackr": ["msgpackr@1.11.8", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
+
+    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -586,9 +630,11 @@
 
     "nerf-dart": ["nerf-dart@1.0.0", "", {}, "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g=="],
 
-    "next": ["next@16.1.1", "", { "dependencies": { "@next/env": "16.1.1", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.1", "@next/swc-darwin-x64": "16.1.1", "@next/swc-linux-arm64-gnu": "16.1.1", "@next/swc-linux-arm64-musl": "16.1.1", "@next/swc-linux-x64-gnu": "16.1.1", "@next/swc-linux-x64-musl": "16.1.1", "@next/swc-win32-arm64-msvc": "16.1.1", "@next/swc-win32-x64-msvc": "16.1.1", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w=="],
+    "next": ["next@16.1.6", "", { "dependencies": { "@next/env": "16.1.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.6", "@next/swc-darwin-x64": "16.1.6", "@next/swc-linux-arm64-gnu": "16.1.6", "@next/swc-linux-arm64-musl": "16.1.6", "@next/swc-linux-x64-gnu": "16.1.6", "@next/swc-linux-x64-musl": "16.1.6", "@next/swc-win32-arm64-msvc": "16.1.6", "@next/swc-win32-x64-msvc": "16.1.6", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw=="],
 
     "node-emoji": ["node-emoji@2.2.0", "", { "dependencies": { "@sindresorhus/is": "^4.6.0", "char-regex": "^1.0.2", "emojilib": "^2.4.0", "skin-tone": "^2.0.0" } }, "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "normalize-package-data": ["normalize-package-data@8.0.0", "", { "dependencies": { "hosted-git-info": "^9.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ=="],
 
@@ -658,11 +704,13 @@
 
     "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
-    "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
+    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
-    "react-dom": ["react-dom@19.2.3", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg=="],
+    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
     "react-image-crop": ["react-image-crop@11.0.10", "", { "peerDependencies": { "react": ">=16.13.1" } }, "sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ=="],
 
@@ -688,11 +736,9 @@
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "semantic-release": ["semantic-release@25.0.2", "", { "dependencies": { "@semantic-release/commit-analyzer": "^13.0.1", "@semantic-release/error": "^4.0.0", "@semantic-release/github": "^12.0.0", "@semantic-release/npm": "^13.1.1", "@semantic-release/release-notes-generator": "^14.1.0", "aggregate-error": "^5.0.0", "cosmiconfig": "^9.0.0", "debug": "^4.0.0", "env-ci": "^11.0.0", "execa": "^9.0.0", "figures": "^6.0.0", "find-versions": "^6.0.0", "get-stream": "^6.0.0", "git-log-parser": "^1.2.0", "hook-std": "^4.0.0", "hosted-git-info": "^9.0.0", "import-from-esm": "^2.0.0", "lodash-es": "^4.17.21", "marked": "^15.0.0", "marked-terminal": "^7.3.0", "micromatch": "^4.0.2", "p-each-series": "^3.0.0", "p-reduce": "^3.0.0", "read-package-up": "^12.0.0", "resolve-from": "^5.0.0", "semver": "^7.3.2", "semver-diff": "^5.0.0", "signale": "^1.2.1", "yargs": "^18.0.0" }, "bin": { "semantic-release": "bin/semantic-release.js" } }, "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g=="],
+    "semantic-release": ["semantic-release@25.0.3", "", { "dependencies": { "@semantic-release/commit-analyzer": "^13.0.1", "@semantic-release/error": "^4.0.0", "@semantic-release/github": "^12.0.0", "@semantic-release/npm": "^13.1.1", "@semantic-release/release-notes-generator": "^14.1.0", "aggregate-error": "^5.0.0", "cosmiconfig": "^9.0.0", "debug": "^4.0.0", "env-ci": "^11.0.0", "execa": "^9.0.0", "figures": "^6.0.0", "find-versions": "^6.0.0", "get-stream": "^6.0.0", "git-log-parser": "^1.2.0", "hook-std": "^4.0.0", "hosted-git-info": "^9.0.0", "import-from-esm": "^2.0.0", "lodash-es": "^4.17.21", "marked": "^15.0.0", "marked-terminal": "^7.3.0", "micromatch": "^4.0.2", "p-each-series": "^3.0.0", "p-reduce": "^3.0.0", "read-package-up": "^12.0.0", "resolve-from": "^5.0.0", "semver": "^7.3.2", "signale": "^1.2.1", "yargs": "^18.0.0" }, "bin": { "semantic-release": "bin/semantic-release.js" } }, "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA=="],
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "semver-diff": ["semver-diff@5.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-0HbGtOm+S7T6NGQ/pxJSJipJvc4DK3FcRVMRkhsIwJDJ4Jcz5DQC1cPPzB5GhzyHjwttW878HaWQq46CkL3cqg=="],
 
     "semver-regex": ["semver-regex@4.0.5", "", {}, "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw=="],
 
@@ -723,6 +769,8 @@
     "spdx-license-ids": ["spdx-license-ids@3.0.22", "", {}, "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ=="],
 
     "split2": ["split2@1.0.0", "", { "dependencies": { "through2": "~2.0.0" } }, "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg=="],
+
+    "sqids": ["sqids@0.3.0", "", {}, "sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw=="],
 
     "stream-combiner2": ["stream-combiner2@1.1.1", "", { "dependencies": { "duplexer2": "~0.1.0", "readable-stream": "^2.0.2" } }, "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw=="],
 
@@ -797,6 +845,8 @@
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "uploadthing": ["uploadthing@7.7.4", "", { "dependencies": { "@effect/platform": "0.90.3", "@standard-schema/spec": "1.0.0-beta.4", "@uploadthing/mime-types": "0.3.6", "@uploadthing/shared": "7.1.10", "effect": "3.17.7" }, "peerDependencies": { "express": "*", "h3": "*", "tailwindcss": "^3.0.0 || ^4.0.0-beta.0" }, "optionalPeers": ["express", "h3", "tailwindcss"] }, "sha512-rlK/4JWHW5jP30syzWGBFDDXv3WJDdT8gn9OoxRJmXLoXi94hBmyyjxihGlNrKhBc81czyv8TkzMioe/OuKGfA=="],
 
     "url-join": ["url-join@5.0.0", "", {}, "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="],
 
@@ -875,6 +925,8 @@
     "cli-table3/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "crypto-random-string/type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
+
+    "effect/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "env-ci/execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 

--- a/package.json
+++ b/package.json
@@ -11,30 +11,30 @@
         "adm-zip": "^0.5.16",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "kokokor": "^2.1.0",
-        "lucide-react": "^0.563.0",
+        "kokokor": "^2.2.0",
+        "lucide-react": "^0.575.0",
         "next": "16.1.6",
         "pdf-lib": "^1.17.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-image-crop": "^11.0.10",
-        "tailwind-merge": "^3.4.0",
+        "tailwind-merge": "^3.5.0",
         "uploadthing": "^7.7.4"
     },
     "description": "OCR pipeline + post-processing for Arabic Islamic books in PDF (PDF upload, page extraction, progress via SSE).",
     "devDependencies": {
-        "@biomejs/biome": "2.3.14",
+        "@biomejs/biome": "2.4.3",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
-        "@tailwindcss/postcss": "^4.1.18",
+        "@tailwindcss/postcss": "^4.2.0",
         "@types/adm-zip": "^0.5.7",
         "@types/bun": "^1.3.9",
-        "@types/node": "^25.2.3",
+        "@types/node": "^25.3.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "babel-plugin-react-compiler": "1.0.0",
         "semantic-release": "^25.0.3",
-        "tailwindcss": "^4.1.18",
+        "tailwindcss": "^4.2.0",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3"
     },
@@ -74,5 +74,5 @@
         "sharp",
         "unrs-resolver"
     ],
-    "version": "1.4.0"
+    "version": "1.3.0"
 }

--- a/package.json
+++ b/package.json
@@ -8,34 +8,38 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "adm-zip": "^0.5.16",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.562.0",
-        "next": "16.1.1",
+        "kokokor": "^2.1.0",
+        "lucide-react": "^0.563.0",
+        "next": "16.1.6",
         "pdf-lib": "^1.17.1",
-        "react": "19.2.3",
-        "react-dom": "19.2.3",
+        "react": "19.2.4",
+        "react-dom": "19.2.4",
         "react-image-crop": "^11.0.10",
-        "tailwind-merge": "^3.4.0"
+        "tailwind-merge": "^3.4.0",
+        "uploadthing": "^7.7.4"
     },
     "description": "OCR pipeline + post-processing for Arabic Islamic books in PDF (PDF upload, page extraction, progress via SSE).",
     "devDependencies": {
-        "@biomejs/biome": "2.3.11",
+        "@biomejs/biome": "2.3.14",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@tailwindcss/postcss": "^4.1.18",
-        "@types/bun": "^1.3.5",
-        "@types/node": "^25.0.3",
-        "@types/react": "^19.2.7",
+        "@types/adm-zip": "^0.5.7",
+        "@types/bun": "^1.3.9",
+        "@types/node": "^25.2.3",
+        "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "babel-plugin-react-compiler": "1.0.0",
-        "semantic-release": "^25.0.2",
+        "semantic-release": "^25.0.3",
         "tailwindcss": "^4.1.18",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3"
     },
     "engines": {
-        "bun": ">=1.3.5",
+        "bun": ">=1.3.9",
         "node": ">=24"
     },
     "homepage": "https://github.com/ragaeeb/swissawa#readme",
@@ -53,7 +57,7 @@
     ],
     "license": "MIT",
     "name": "swissawa",
-    "packageManager": "bun@1.3.5",
+    "packageManager": "bun@1.3.9",
     "private": true,
     "repository": {
         "type": "git",
@@ -70,5 +74,5 @@
         "sharp",
         "unrs-resolver"
     ],
-    "version": "1.3.0"
+    "version": "1.4.0"
 }

--- a/src/app/api/jobs/[jobId]/ocr/pages/route.test.ts
+++ b/src/app/api/jobs/[jobId]/ocr/pages/route.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import * as fsp from 'node:fs/promises';
+import path from 'node:path';
+import { jobDir, jobImagesDir, jobPdfPath } from '@/server/jobs/jobPaths';
+import { globalJobStore } from '@/server/jobs/jobStore';
+import { jobOcrMetaPath, jobOcrPagesDir } from '@/server/ocr/ocrPaths';
+import { GET } from './route';
+
+describe('GET /api/jobs/[jobId]/ocr/pages', () => {
+    let jobId = '';
+
+    beforeEach(async () => {
+        jobId = randomUUID();
+        await fsp.mkdir(jobDir(jobId), { recursive: true });
+        await fsp.writeFile(jobPdfPath(jobId), '%PDF-1.7 fake', 'utf8');
+        globalJobStore.create({
+            id: jobId,
+            info: undefined,
+            ocr: { status: 'complete', updatedAtMs: Date.now() },
+            outputDir: jobImagesDir(jobId),
+            pdfPath: jobPdfPath(jobId),
+            progress: { extractedPages: 0, totalPages: 2 },
+            status: 'complete',
+        });
+    });
+
+    afterEach(async () => {
+        globalJobStore.delete(jobId);
+        await fsp.rm(jobDir(jobId), { force: true, recursive: true });
+    });
+
+    it('should return 404 when pages dir is missing', async () => {
+        const req = new Request(`http://localhost/api/jobs/${jobId}/ocr/pages`);
+        const res = await GET(req, { params: Promise.resolve({ jobId }) });
+        expect(res.status).toBe(404);
+    });
+
+    it('should return sorted pages when json files exist', async () => {
+        await fsp.mkdir(jobOcrPagesDir(jobId), { recursive: true });
+        await fsp.writeFile(jobOcrMetaPath(jobId), JSON.stringify({ dpi: { x: 330, y: 330 }, totalPages: 2 }), 'utf8');
+        await fsp.writeFile(
+            path.join(jobOcrPagesDir(jobId), '2.json'),
+            JSON.stringify({
+                height: 100,
+                observations: [{ bbox: { height: 1, width: 1, x: 0, y: 0 }, text: 'b' }],
+                page: 2,
+                width: 100,
+            }),
+            'utf8',
+        );
+        await fsp.writeFile(
+            path.join(jobOcrPagesDir(jobId), '1.json'),
+            JSON.stringify({
+                height: 100,
+                observations: [{ bbox: { height: 1, width: 1, x: 0, y: 0 }, text: 'a' }],
+                page: 1,
+                width: 100,
+            }),
+            'utf8',
+        );
+
+        const req = new Request(`http://localhost/api/jobs/${jobId}/ocr/pages`);
+        const res = await GET(req, { params: Promise.resolve({ jobId }) });
+        expect(res.status).toBe(200);
+
+        const data = (await res.json()) as { dpi?: { x: number; y: number }; pages: Array<{ page: number }> };
+        expect(data.pages.length).toBe(2);
+        expect(data.pages[0]?.page).toBe(1);
+        expect(data.pages[1]?.page).toBe(2);
+        expect(data.dpi).toEqual({ x: 330, y: 330 });
+    });
+});

--- a/src/app/api/jobs/[jobId]/ocr/pages/route.ts
+++ b/src/app/api/jobs/[jobId]/ocr/pages/route.ts
@@ -1,0 +1,80 @@
+import * as fsp from 'node:fs/promises';
+import path from 'node:path';
+import type { Coordinates, ObservationPage } from '@/lib/macOcr';
+import { readJobSnapshot } from '@/server/jobs/jobSnapshot';
+import { globalJobStore } from '@/server/jobs/jobStore';
+import { jobOcrMetaPath, jobOcrPagesDir } from '@/server/ocr/ocrPaths';
+
+export const runtime = 'nodejs';
+
+const PAGE_FILE_RE = /^(\d+)\.json$/;
+
+const listSortedPageFiles = async (pagesDir: string): Promise<string[]> => {
+    const files = await fsp.readdir(pagesDir);
+    return files
+        .filter((name) => PAGE_FILE_RE.test(name))
+        .sort((a, b) => Number.parseInt(a, 10) - Number.parseInt(b, 10));
+};
+
+const readPageJson = async (pagesDir: string, fileName: string): Promise<ObservationPage | null> => {
+    try {
+        const raw = await fsp.readFile(path.join(pagesDir, fileName), 'utf8');
+        const page = JSON.parse(raw) as ObservationPage;
+        if (!Number.isInteger(page.page) || page.page <= 0 || !Array.isArray(page.observations)) {
+            return null;
+        }
+        return page;
+    } catch {
+        return null;
+    }
+};
+
+const readDpiFromMeta = async (jobId: string): Promise<Coordinates | undefined> => {
+    try {
+        const raw = await fsp.readFile(jobOcrMetaPath(jobId), 'utf8');
+        const data = JSON.parse(raw) as { dpi?: Coordinates };
+        const x = Number(data?.dpi?.x);
+        const y = Number(data?.dpi?.y);
+        if (!Number.isFinite(x) || !Number.isFinite(y) || x <= 0 || y <= 0) {
+            return undefined;
+        }
+        return { x, y };
+    } catch {
+        return undefined;
+    }
+};
+
+export const GET = async (_request: Request, ctx: { params: Promise<{ jobId: string }> }): Promise<Response> => {
+    const { jobId } = await ctx.params;
+    const job = globalJobStore.get(jobId) ?? (await readJobSnapshot(jobId));
+    if (!job) {
+        return Response.json({ error: 'Job not found' }, { status: 404 });
+    }
+
+    const pagesDir = jobOcrPagesDir(jobId);
+    let fileNames: string[];
+    try {
+        fileNames = await listSortedPageFiles(pagesDir);
+    } catch {
+        return Response.json({ error: 'OCR pages not found' }, { status: 404 });
+    }
+
+    const pages: ObservationPage[] = [];
+    for (const fileName of fileNames) {
+        const page = await readPageJson(pagesDir, fileName);
+        if (page) {
+            pages.push(page);
+        }
+    }
+
+    const dpi = await readDpiFromMeta(jobId);
+
+    return Response.json(
+        { dpi, pages },
+        {
+            headers: {
+                'Cache-Control': job.ocr?.status === 'complete' ? 'public, max-age=3600, immutable' : 'no-store',
+            },
+        },
+    );
+};

--- a/src/app/api/jobs/[jobId]/ocr/route.test.ts
+++ b/src/app/api/jobs/[jobId]/ocr/route.test.ts
@@ -7,15 +7,15 @@ import { globalJobStore } from '@/server/jobs/jobStore';
 import { jobOcrDir, jobOcrJsonPath } from '@/server/ocr/ocrPaths';
 import { GET, POST } from './route';
 
-mock.module('@/server/ocr/runMacOcr', () => ({
-    runMacOcr: mock(async ({ jobId, store }: { jobId: string; store: any }) => {
-        store.update(jobId, (j: any) => {
-            j.ocr = { language: 'ar-SA', status: 'complete', updatedAtMs: Date.now() };
-        });
-        await fsp.mkdir(jobOcrDir(jobId), { recursive: true });
-        await fsp.writeFile(jobOcrJsonPath(jobId), JSON.stringify({ dpi: { x: 300, y: 300 }, pages: [] }), 'utf8');
-    }),
-}));
+const providerStartMock = mock(async ({ jobId, store }: { jobId: string; store: any }) => {
+    store.update(jobId, (j: any) => {
+        j.ocr = { language: 'ar-SA', status: 'complete', updatedAtMs: Date.now() };
+    });
+    await fsp.mkdir(jobOcrDir(jobId), { recursive: true });
+    await fsp.writeFile(jobOcrJsonPath(jobId), JSON.stringify({ dpi: { x: 300, y: 300 }, pages: [] }), 'utf8');
+});
+
+mock.module('@/server/ocr/providers', () => ({ getMacOcrProvider: () => ({ start: providerStartMock }) }));
 
 describe('GET/POST /api/jobs/[jobId]/ocr', () => {
     let jobId = '';
@@ -31,6 +31,7 @@ describe('GET/POST /api/jobs/[jobId]/ocr', () => {
     }
 
     beforeEach(async () => {
+        providerStartMock.mockClear();
         jobId = randomUUID();
         await fsp.mkdir(jobDir(jobId), { recursive: true });
         await fsp.writeFile(jobPdfPath(jobId), '%PDF-1.7 fake', 'utf8');
@@ -63,6 +64,7 @@ describe('GET/POST /api/jobs/[jobId]/ocr', () => {
         expect(res.status).toBe(200);
         const body = (await res.json()) as any;
         expect(body.status).toBe('running');
+        expect(providerStartMock).toHaveBeenCalledTimes(1);
 
         // Ensure background OCR finishes before test cleanup (prevents noisy logs).
         await waitForAsync(async () => {

--- a/src/app/api/jobs/[jobId]/ocr/route.ts
+++ b/src/app/api/jobs/[jobId]/ocr/route.ts
@@ -5,7 +5,7 @@ import { globalJobStore } from '@/server/jobs/jobStore';
 import type { OcrDeliveryPreferredKind } from '@/server/ocr/ocrDelivery';
 import { selectOcrDelivery } from '@/server/ocr/ocrDelivery';
 import { jobOcrJsonPath, jobOcrMetaPath, jobOcrPagesDir } from '@/server/ocr/ocrPaths';
-import { runMacOcr } from '@/server/ocr/runMacOcr';
+import { getMacOcrProvider } from '@/server/ocr/providers';
 
 export const runtime = 'nodejs';
 
@@ -84,7 +84,8 @@ export async function POST(_request: Request, ctx: { params: Promise<{ jobId: st
 
     // Fire-and-forget: OCR can take a long time; the UI should poll GET /ocr for status.
     console.info('[jobs.ocr.start]', { jobId });
-    void runMacOcr({ jobId, store: globalJobStore }).catch((err: unknown) => {
+    const provider = getMacOcrProvider();
+    void provider.start({ jobId, store: globalJobStore }).catch((err: unknown) => {
         console.error('[jobs.ocr]', { jobId, message: err instanceof Error ? err.message : String(err) });
     });
     return Response.json({ status: 'running' });

--- a/src/app/api/jobs/[jobId]/surya/pages/route.test.ts
+++ b/src/app/api/jobs/[jobId]/surya/pages/route.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import * as fsp from 'node:fs/promises';
+import path from 'node:path';
+import { jobDir, jobImagesDir, jobPdfPath } from '@/server/jobs/jobPaths';
+import { globalJobStore } from '@/server/jobs/jobStore';
+import { jobSuryaPagesDir } from '@/server/ocr/ocrPaths';
+import { GET } from './route';
+
+describe('GET /api/jobs/[jobId]/surya/pages', () => {
+    let jobId = '';
+
+    beforeEach(async () => {
+        jobId = randomUUID();
+        await fsp.mkdir(jobDir(jobId), { recursive: true });
+        await fsp.writeFile(jobPdfPath(jobId), '%PDF-1.7 fake', 'utf8');
+        globalJobStore.create({
+            id: jobId,
+            info: undefined,
+            outputDir: jobImagesDir(jobId),
+            pdfPath: jobPdfPath(jobId),
+            progress: { extractedPages: 0, totalPages: 2 },
+            status: 'complete',
+            suryaOcr: { status: 'complete', updatedAtMs: Date.now() },
+        });
+    });
+
+    afterEach(async () => {
+        globalJobStore.delete(jobId);
+        await fsp.rm(jobDir(jobId), { force: true, recursive: true });
+    });
+
+    it('should return 404 when pages dir is missing', async () => {
+        const req = new Request(`http://localhost/api/jobs/${jobId}/surya/pages`);
+        const res = await GET(req, { params: Promise.resolve({ jobId }) });
+        expect(res.status).toBe(404);
+    });
+
+    it('should return sorted pages when json files exist', async () => {
+        await fsp.mkdir(jobSuryaPagesDir(jobId), { recursive: true });
+        await fsp.writeFile(
+            path.join(jobSuryaPagesDir(jobId), '2.json'),
+            JSON.stringify({
+                height: 100,
+                observations: [{ bbox: { height: 1, width: 1, x: 0, y: 0 }, text: 'b' }],
+                page: 2,
+                width: 100,
+            }),
+            'utf8',
+        );
+        await fsp.writeFile(
+            path.join(jobSuryaPagesDir(jobId), '1.json'),
+            JSON.stringify({
+                height: 100,
+                observations: [{ bbox: { height: 1, width: 1, x: 0, y: 0 }, text: 'a' }],
+                page: 1,
+                width: 100,
+            }),
+            'utf8',
+        );
+
+        const req = new Request(`http://localhost/api/jobs/${jobId}/surya/pages`);
+        const res = await GET(req, { params: Promise.resolve({ jobId }) });
+        expect(res.status).toBe(200);
+
+        const data = (await res.json()) as { pages: Array<{ page: number }> };
+        expect(data.pages.length).toBe(2);
+        expect(data.pages[0]?.page).toBe(1);
+        expect(data.pages[1]?.page).toBe(2);
+    });
+});

--- a/src/app/api/jobs/[jobId]/surya/pages/route.ts
+++ b/src/app/api/jobs/[jobId]/surya/pages/route.ts
@@ -1,0 +1,63 @@
+import * as fsp from 'node:fs/promises';
+import path from 'node:path';
+import type { ObservationPage } from '@/lib/macOcr';
+import { readJobSnapshot } from '@/server/jobs/jobSnapshot';
+import { globalJobStore } from '@/server/jobs/jobStore';
+import { jobSuryaPagesDir } from '@/server/ocr/ocrPaths';
+
+export const runtime = 'nodejs';
+
+const PAGE_FILE_RE = /^(\d+)\.json$/;
+
+const listSortedPageFiles = async (pagesDir: string): Promise<string[]> => {
+    const files = await fsp.readdir(pagesDir);
+    return files
+        .filter((name) => PAGE_FILE_RE.test(name))
+        .sort((a, b) => Number.parseInt(a, 10) - Number.parseInt(b, 10));
+};
+
+const readPageJson = async (pagesDir: string, fileName: string): Promise<ObservationPage | null> => {
+    try {
+        const raw = await fsp.readFile(path.join(pagesDir, fileName), 'utf8');
+        const page = JSON.parse(raw) as ObservationPage;
+        if (!Number.isInteger(page.page) || page.page <= 0 || !Array.isArray(page.observations)) {
+            return null;
+        }
+        return page;
+    } catch {
+        return null;
+    }
+};
+
+export const GET = async (_request: Request, ctx: { params: Promise<{ jobId: string }> }): Promise<Response> => {
+    const { jobId } = await ctx.params;
+    const job = globalJobStore.get(jobId) ?? (await readJobSnapshot(jobId));
+    if (!job) {
+        return Response.json({ error: 'Job not found' }, { status: 404 });
+    }
+
+    const pagesDir = jobSuryaPagesDir(jobId);
+    let fileNames: string[];
+    try {
+        fileNames = await listSortedPageFiles(pagesDir);
+    } catch {
+        return Response.json({ error: 'Surya OCR pages not found' }, { status: 404 });
+    }
+
+    const pages: ObservationPage[] = [];
+    for (const fileName of fileNames) {
+        const page = await readPageJson(pagesDir, fileName);
+        if (page) {
+            pages.push(page);
+        }
+    }
+
+    return Response.json(
+        { pages },
+        {
+            headers: {
+                'Cache-Control': job.suryaOcr?.status === 'complete' ? 'public, max-age=3600, immutable' : 'no-store',
+            },
+        },
+    );
+};

--- a/src/app/api/jobs/[jobId]/surya/route.ts
+++ b/src/app/api/jobs/[jobId]/surya/route.ts
@@ -1,7 +1,7 @@
 import * as fsp from 'node:fs/promises';
 import { readJobSnapshot } from '@/server/jobs/jobSnapshot';
 import { globalJobStore } from '@/server/jobs/jobStore';
-import { jobSuryaMetaPath, jobSuryaOcrJsonPath, jobSuryaPagesDir } from '@/server/ocr/ocrPaths';
+import { jobSuryaMetaPath, jobSuryaPagesDir } from '@/server/ocr/ocrPaths';
 import { runSuryaOcr } from '@/server/ocr/runSuryaOcr';
 
 export const runtime = 'nodejs';

--- a/src/app/api/skalu/analyze/route.ts
+++ b/src/app/api/skalu/analyze/route.ts
@@ -1,0 +1,51 @@
+import type { AnalyzeApiResponse, SkaluApiResponse } from '@/lib/skalu';
+
+export const runtime = 'nodejs';
+
+const parseJsonBody = (request: Request): Promise<unknown> => request.json().catch(() => null);
+
+const isHttpUrl = (raw: string): boolean => {
+    try {
+        const u = new URL(raw);
+        return u.protocol === 'http:' || u.protocol === 'https:';
+    } catch {
+        return false;
+    }
+};
+
+export const POST = async (request: Request): Promise<Response> => {
+    const contentType = request.headers.get('content-type') ?? '';
+    if (!contentType.toLowerCase().includes('application/json')) {
+        return Response.json({ error: 'Expected application/json' }, { status: 400 });
+    }
+
+    const json = await parseJsonBody(request);
+    console.log('json', json);
+    const url = (json as any)?.url as unknown;
+    if (typeof url !== 'string' || !isHttpUrl(url)) {
+        return Response.json({ error: 'Invalid url' }, { status: 400 });
+    }
+
+    try {
+        const form = new FormData();
+        form.append('file_url', url);
+        form.append('include_visualizations', 'false');
+
+        console.log('fetching', `${process.env.SWISSAWA_SKALU_BASE_URL}/analyze`);
+
+        const res = await fetch(`${process.env.SWISSAWA_SKALU_BASE_URL}/analyze`, { body: form, method: 'POST' });
+
+        if (!res.ok) {
+            return Response.json({ error: `Skalu analyze failed (${res.status})` }, { status: 502 });
+        }
+
+        console.log('decod response');
+
+        const body = (await res.json()) as SkaluApiResponse;
+        console.log('body', body);
+        const response: AnalyzeApiResponse = { pages: body.result_data.pages };
+        return Response.json(response);
+    } catch (err: unknown) {
+        return Response.json({ error: err instanceof Error ? err.message : 'Unknown error' }, { status: 500 });
+    }
+};

--- a/src/app/api/upload-url/route.ts
+++ b/src/app/api/upload-url/route.ts
@@ -1,10 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto';
-import * as fsp from 'node:fs/promises';
-import { readHashIndex, writeHashIndex } from '@/server/jobs/hashIndex';
-import { jobDir, jobImagesDir, jobPdfPath } from '@/server/jobs/jobPaths';
-import { writeJobSnapshot } from '@/server/jobs/jobSnapshot';
-import { globalJobStore } from '@/server/jobs/jobStore';
-import { runPdfExtractionJob } from '@/server/pdf/runner';
+import { createJobFromPdfBytes } from '@/server/jobs/createJobFromPdfBytes';
 
 export const runtime = 'nodejs';
 
@@ -89,45 +83,13 @@ export async function POST(request: Request): Promise<Response> {
         }
 
         const bytes = await readAllBytesWithLimit(res.body, maxBytes);
-        const sha256 = createHash('sha256').update(bytes).digest('hex');
-
-        const existing = await readHashIndex(sha256);
-        if (existing) {
-            console.info('[upload.url.reuse]', { jobId: existing.jobId, sha256, url });
-            return Response.json({ jobId: existing.jobId, reused: true, sha256 });
-        }
-
-        const jobId = randomUUID();
-        const dir = jobDir(jobId);
-        const outputDir = jobImagesDir(jobId);
-        const pdfPath = jobPdfPath(jobId);
-
-        await fsp.mkdir(dir, { recursive: true });
-        await fsp.writeFile(pdfPath, bytes);
-
-        const job = globalJobStore.create({
-            id: jobId,
-            info: undefined,
-            outputDir,
-            pdfPath,
-            progress: { extractedPages: 0, totalPages: undefined },
-            sourceUrl: url,
-            status: 'uploaded',
+        const created = await createJobFromPdfBytes({ bytes, sourceUrl: url });
+        console.info(created.reused ? '[upload.url.reuse]' : '[upload.url.created]', {
+            jobId: created.jobId,
+            sha256: created.sha256,
+            url,
         });
-        await writeJobSnapshot(job);
-        await writeHashIndex({ createdAtMs: Date.now(), hash: sha256, jobId });
-        console.info('[upload.url.created]', { jobId, sha256, url });
-
-        runPdfExtractionJob({ jobId, store: globalJobStore }).catch((err: unknown) => {
-            const bus = globalJobStore.bus(jobId);
-            globalJobStore.update(jobId, (j) => {
-                j.status = 'error';
-                j.error = err instanceof Error ? err.message : 'Unknown error';
-            });
-            bus?.emit('error', err instanceof Error ? err.message : 'Unknown error');
-        });
-
-        return Response.json({ jobId, reused: false, sha256 });
+        return Response.json(created);
     } catch (err: unknown) {
         if (err instanceof Error && err.message.includes('maximum allowed size')) {
             return Response.json({ error: err.message }, { status: 413 });

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,11 +1,5 @@
-import { createHash, randomUUID } from 'node:crypto';
-import * as fsp from 'node:fs/promises';
 import { parseMultipartStream } from '@mjackson/multipart-parser';
-import { readHashIndex, writeHashIndex } from '@/server/jobs/hashIndex';
-import { jobDir, jobImagesDir, jobPdfPath } from '@/server/jobs/jobPaths';
-import { writeJobSnapshot } from '@/server/jobs/jobSnapshot';
-import { globalJobStore } from '@/server/jobs/jobStore';
-import { runPdfExtractionJob } from '@/server/pdf/runner';
+import { createJobFromPdfBytes } from '@/server/jobs/createJobFromPdfBytes';
 
 export const runtime = 'nodejs';
 
@@ -80,43 +74,12 @@ export const POST = async (request: Request): Promise<Response> => {
             return Response.json({ error: 'No file uploaded' }, { status: 400 });
         }
 
-        const sha256 = createHash('sha256').update(fileBytes).digest('hex');
-        const existing = await readHashIndex(sha256);
-        if (existing) {
-            console.info('[upload.reuse]', { jobId: existing.jobId, sha256 });
-            return Response.json({ jobId: existing.jobId, reused: true, sha256 });
-        }
-
-        const jobId = randomUUID();
-        const dir = jobDir(jobId);
-        const outputDir = jobImagesDir(jobId);
-        const pdfPath = jobPdfPath(jobId);
-
-        await fsp.mkdir(dir, { recursive: true });
-        await fsp.writeFile(pdfPath, fileBytes);
-
-        const job = globalJobStore.create({
-            id: jobId,
-            info: undefined,
-            outputDir,
-            pdfPath,
-            progress: { extractedPages: 0, totalPages: undefined },
-            status: 'uploaded',
+        const created = await createJobFromPdfBytes({ bytes: fileBytes });
+        console.info(created.reused ? '[upload.reuse]' : '[upload.created]', {
+            jobId: created.jobId,
+            sha256: created.sha256,
         });
-        await writeJobSnapshot(job);
-        await writeHashIndex({ createdAtMs: Date.now(), hash: sha256, jobId });
-        console.info('[upload.created]', { jobId, sha256 });
-
-        runPdfExtractionJob({ jobId, store: globalJobStore }).catch((err: unknown) => {
-            const bus = globalJobStore.bus(jobId);
-            globalJobStore.update(jobId, (j) => {
-                j.status = 'error';
-                j.error = err instanceof Error ? err.message : 'Unknown error';
-            });
-            bus?.emit('error', err instanceof Error ? err.message : 'Unknown error');
-        });
-
-        return Response.json({ jobId, reused: false, sha256 });
+        return Response.json(created);
     } catch (err: any) {
         if (
             err instanceof Error &&

--- a/src/app/api/uploadthing/core.ts
+++ b/src/app/api/uploadthing/core.ts
@@ -1,0 +1,13 @@
+import { createUploadthing, type FileRouter } from 'uploadthing/next';
+
+const f = createUploadthing();
+
+export const uploadRouter = {
+    pdfUploader: f({ pdf: { maxFileCount: 1, maxFileSize: '64MB' } }, { awaitServerData: false }).onUploadComplete(
+        async () => {
+            return;
+        },
+    ),
+} satisfies FileRouter;
+
+export type UploadRouter = typeof uploadRouter;

--- a/src/app/api/uploadthing/ingest/route.test.ts
+++ b/src/app/api/uploadthing/ingest/route.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { POST } from './route';
+
+const testContext = {
+    createJobResult: { jobId: 'job-1', reused: false, sha256: 'abc' },
+    fetchBody: new TextEncoder().encode('%PDF-1.7 UT'),
+    fetchContentType: 'application/pdf',
+    fetchOk: true,
+    signedUrl: 'https://files.example.com/file.pdf',
+    throwSignedUrl: false,
+};
+
+mock.module('uploadthing/server', () => ({
+    UTApi: class {
+        async generateSignedURL(_key: string) {
+            if (testContext.throwSignedUrl) {
+                throw new Error('signed-url-failed');
+            }
+            return { ufsUrl: testContext.signedUrl };
+        }
+    },
+}));
+
+mock.module('@/server/jobs/createJobFromPdfBytes', () => ({
+    createJobFromPdfBytes: mock(async () => testContext.createJobResult),
+}));
+
+function streamFromBytes(bytes: Uint8Array): ReadableStream<Uint8Array> {
+    return new ReadableStream({
+        start(controller) {
+            controller.enqueue(bytes);
+            controller.close();
+        },
+    });
+}
+
+describe('POST /api/uploadthing/ingest', () => {
+    beforeEach(() => {
+        testContext.fetchOk = true;
+        testContext.fetchContentType = 'application/pdf';
+        testContext.fetchBody = new TextEncoder().encode('%PDF-1.7');
+        testContext.throwSignedUrl = false;
+    });
+
+    afterEach(() => {
+        mock.restore();
+    });
+
+    it('returns 400 for missing key', async () => {
+        const req = new Request('http://localhost/api/uploadthing/ingest', {
+            body: JSON.stringify({}),
+            headers: { 'content-type': 'application/json' },
+            method: 'POST',
+        });
+        const res = await POST(req);
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when fetched file is not pdf', async () => {
+        testContext.fetchContentType = 'image/png';
+        // @ts-expect-error test mock
+        global.fetch = mock(async () => {
+            return new Response(streamFromBytes(testContext.fetchBody), {
+                headers: { 'content-type': testContext.fetchContentType },
+                status: 200,
+            });
+        });
+
+        const req = new Request('http://localhost/api/uploadthing/ingest', {
+            body: JSON.stringify({ key: 'file-key' }),
+            headers: { 'content-type': 'application/json' },
+            method: 'POST',
+        });
+        const res = await POST(req);
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 200 with job payload on success', async () => {
+        // @ts-expect-error test mock
+        global.fetch = mock(async () => {
+            return new Response(streamFromBytes(testContext.fetchBody), {
+                headers: { 'content-type': testContext.fetchContentType },
+                status: 200,
+            });
+        });
+
+        const req = new Request('http://localhost/api/uploadthing/ingest', {
+            body: JSON.stringify({ key: 'file-key' }),
+            headers: { 'content-type': 'application/json' },
+            method: 'POST',
+        });
+        const res = await POST(req);
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as any;
+        expect(body.jobId).toBe(testContext.createJobResult.jobId);
+    });
+});

--- a/src/app/api/uploadthing/ingest/route.ts
+++ b/src/app/api/uploadthing/ingest/route.ts
@@ -1,0 +1,83 @@
+import { UTApi } from 'uploadthing/server';
+import { createJobFromPdfBytes } from '@/server/jobs/createJobFromPdfBytes';
+
+export const runtime = 'nodejs';
+
+const DEFAULT_MAX_UPLOAD_BYTES = 64 * 1024 * 1024;
+
+function readMaxUploadBytesFromEnv(): number {
+    const raw = process.env.SWISSAWA_MAX_UPLOAD_BYTES;
+    if (!raw) {
+        return DEFAULT_MAX_UPLOAD_BYTES;
+    }
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isFinite(n) || n <= 0) {
+        return DEFAULT_MAX_UPLOAD_BYTES;
+    }
+    return n;
+}
+
+function parseBody(request: Request): Promise<{ key?: unknown }> {
+    return request.json().catch(() => ({}));
+}
+
+async function readAllBytesWithLimit(stream: ReadableStream<Uint8Array>, maxBytes: number): Promise<Uint8Array> {
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+            break;
+        }
+        if (!value) {
+            continue;
+        }
+        total += value.byteLength;
+        if (total > maxBytes) {
+            throw new Error('Remote file exceeds maximum allowed size');
+        }
+        chunks.push(value);
+    }
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) {
+        out.set(c, offset);
+        offset += c.byteLength;
+    }
+    return out;
+}
+
+export async function POST(request: Request): Promise<Response> {
+    const body = await parseBody(request);
+    const key = typeof body.key === 'string' ? body.key : null;
+    if (!key) {
+        return Response.json({ error: 'Missing file key' }, { status: 400 });
+    }
+
+    try {
+        const utapi = new UTApi();
+        const { ufsUrl } = await utapi.generateSignedURL(key, { expiresIn: '10 minutes' });
+        const response = await fetch(ufsUrl, { redirect: 'follow' });
+        if (!response.ok) {
+            return Response.json({ error: `Failed to download uploaded file (${response.status})` }, { status: 400 });
+        }
+
+        const contentType = response.headers.get('content-type') ?? '';
+        if (!contentType.toLowerCase().includes('application/pdf')) {
+            return Response.json({ error: 'Only PDF files are supported' }, { status: 400 });
+        }
+        if (!response.body) {
+            return Response.json({ error: 'Missing response body' }, { status: 500 });
+        }
+
+        const bytes = await readAllBytesWithLimit(response.body, readMaxUploadBytesFromEnv());
+        const created = await createJobFromPdfBytes({ bytes });
+        return Response.json(created);
+    } catch (err: unknown) {
+        if (err instanceof Error && err.message.includes('maximum allowed size')) {
+            return Response.json({ error: err.message }, { status: 413 });
+        }
+        return Response.json({ error: err instanceof Error ? err.message : 'Unknown error' }, { status: 500 });
+    }
+}

--- a/src/app/api/uploadthing/route.ts
+++ b/src/app/api/uploadthing/route.ts
@@ -1,0 +1,6 @@
+import { createRouteHandler } from 'uploadthing/next';
+import { uploadRouter } from './core';
+
+export const runtime = 'nodejs';
+
+export const { GET, POST } = createRouteHandler({ router: uploadRouter });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { UploadZone } from '@/components/UploadZone';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import type { AnalyzeApiResponse } from '@/lib/skalu';
 import { uploadthingClient } from '@/lib/uploadthing';
 import type { CropBox } from '@/server/crop/crop';
 
@@ -22,10 +23,13 @@ export default function Home() {
     const [pages, setPages] = useState<number | null>(null);
     const [extractedPages, setExtractedPages] = useState<number>(0);
     const [meta, setMeta] = useState<Record<string, unknown> | null>(null);
+    const [jobSourceUrl, setJobSourceUrl] = useState<string | null>(null);
     const [previewCount, setPreviewCount] = useState<number>(24);
     const [crop, setCrop] = useState<CropBox | null>(null);
     const [cropPage, setCropPage] = useState<number | null>(null);
     const [cropOpen, setCropOpen] = useState(false);
+    const [detectingStructures, setDetectingStructures] = useState(false);
+    const [analyzeResult, setAnalyzeResult] = useState<AnalyzeApiResponse | null>(null);
 
     const esRef = useRef<EventSource | null>(null);
 
@@ -44,9 +48,31 @@ export default function Home() {
             return;
         }
         const saved = localStorage.getItem('swissawa:lastJobId');
-        if (saved) {
-            setJobId(saved);
+        if (!saved) {
+            return;
         }
+
+        const controller = new AbortController();
+        void (async () => {
+            try {
+                const res = await fetch(`/api/jobs/${encodeURIComponent(saved)}`, { signal: controller.signal });
+                if (!res.ok) {
+                    if (res.status === 404) {
+                        localStorage.removeItem('swissawa:lastJobId');
+                    }
+                    return;
+                }
+                setJobId(saved);
+            } catch (err: unknown) {
+                if (err instanceof Error && err.name === 'AbortError') {
+                    return;
+                }
+            }
+        })();
+
+        return () => {
+            controller.abort();
+        };
     }, [jobId]);
 
     const progressPct = useMemo(() => {
@@ -61,6 +87,7 @@ export default function Home() {
             status: string;
             progress: { extractedPages?: number; totalPages?: number };
             info?: Record<string, unknown> | null;
+            sourceUrl?: string;
         };
     };
 
@@ -82,6 +109,7 @@ export default function Home() {
                 setExtractedPages(data.job.progress.extractedPages ?? 0);
                 setPages(data.job.progress.totalPages ?? null);
                 setMeta(data.job.info ?? null);
+                setJobSourceUrl(data.job.sourceUrl ?? null);
             } catch (err: unknown) {
                 if (err instanceof Error && err.name === 'AbortError') {
                     return;
@@ -116,6 +144,7 @@ export default function Home() {
             setExtractedPages(data.job.progress.extractedPages ?? 0);
             setPages(data.job.progress.totalPages ?? null);
             setMeta(data.job.info ?? null);
+            setJobSourceUrl(typeof data.job.sourceUrl === 'string' ? data.job.sourceUrl : null);
         });
 
         es.addEventListener('pdf', (ev) => {
@@ -186,6 +215,8 @@ export default function Home() {
             setJobId(null);
             setPages(null);
             setMeta(null);
+            setJobSourceUrl(null);
+            setAnalyzeResult(null);
             setExtractedPages(0);
             setCrop(null);
             setCropOpen(false);
@@ -244,6 +275,8 @@ export default function Home() {
             setJobId(null);
             setPages(null);
             setMeta(null);
+            setJobSourceUrl(null);
+            setAnalyzeResult(null);
             setExtractedPages(0);
             setCrop(null);
             setCropOpen(false);
@@ -267,6 +300,35 @@ export default function Home() {
             setStatus('error');
         } finally {
             setUrlUploading(false);
+        }
+    };
+
+    const detectStructures = async () => {
+        const url = pdfUrl.trim() || jobSourceUrl?.trim() || '';
+        if (!url) {
+            return;
+        }
+
+        try {
+            setDetectingStructures(true);
+            const res = await fetch('/api/skalu/analyze', {
+                body: JSON.stringify({ url }),
+                headers: { 'content-type': 'application/json' },
+                method: 'POST',
+            });
+
+            if (!res.ok) {
+                const body = await res.json().catch(() => null);
+                throw new Error(body?.error ?? `Detect structures failed (${res.status})`);
+            }
+
+            const data = (await res.json()) as AnalyzeApiResponse;
+            setAnalyzeResult(data);
+            console.info('[skalu.detect-structures.result]', data);
+        } catch (err: unknown) {
+            console.error('[skalu.detect-structures.error]', err);
+        } finally {
+            setDetectingStructures(false);
         }
     };
 
@@ -303,6 +365,8 @@ export default function Home() {
             setJobId(null);
             setPages(null);
             setMeta(null);
+            setJobSourceUrl(null);
+            setAnalyzeResult(null);
             setExtractedPages(0);
             setStatus('idle');
             setPreviewCount(24);
@@ -393,6 +457,12 @@ export default function Home() {
                         previewPages={previewPages}
                         onLoadMore={() => setPreviewCount((c) => c + 24)}
                         canLoadMore={canLoadMore}
+                        canDetectStructures={Boolean(pdfUrl.trim() || jobSourceUrl?.trim())}
+                        detectingStructures={detectingStructures}
+                        onDetectStructures={() => {
+                            void detectStructures();
+                        }}
+                        analyzeResult={analyzeResult}
                         crop={crop}
                         onCropPage={(p) => {
                             setCropPage(p);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,9 +8,11 @@ import { UploadZone } from '@/components/UploadZone';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { uploadthingClient } from '@/lib/uploadthing';
 import type { CropBox } from '@/server/crop/crop';
 
 export default function Home() {
+    const uploadMode = process.env.NEXT_PUBLIC_SWISSAWA_UPLOAD_MODE === 'uploadthing' ? 'uploadthing' : 'direct';
     const [uploading, setUploading] = useState(false);
     const [urlUploading, setUrlUploading] = useState(false);
     const [pdfUrl, setPdfUrl] = useState('');
@@ -189,10 +191,23 @@ export default function Home() {
             setCropOpen(false);
             setCropPage(null);
 
-            const form = new FormData();
-            form.append('file', file);
-
-            const resp = await fetch('/api/upload', { body: form, method: 'POST' });
+            let resp: Response;
+            if (uploadMode === 'uploadthing') {
+                const uploaded = await uploadthingClient.uploadFiles('pdfUploader', { files: [file] });
+                const key = uploaded[0]?.key;
+                if (!key) {
+                    throw new Error('UploadThing upload did not return a file key');
+                }
+                resp = await fetch('/api/uploadthing/ingest', {
+                    body: JSON.stringify({ key }),
+                    headers: { 'content-type': 'application/json' },
+                    method: 'POST',
+                });
+            } else {
+                const form = new FormData();
+                form.append('file', file);
+                resp = await fetch('/api/upload', { body: form, method: 'POST' });
+            }
             if (!resp.ok) {
                 const body = await resp.json().catch(() => null);
                 throw new Error(body?.error ?? `Upload failed (${resp.status})`);

--- a/src/components/PageOcrTable.tsx
+++ b/src/components/PageOcrTable.tsx
@@ -5,7 +5,8 @@ import Image from 'next/image';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import type { ObservationPage } from '@/lib/macOcr';
+import type { Coordinates, ObservationPage } from '@/lib/macOcr';
+import type { AnalyzeApiResponse } from '@/lib/skalu';
 import type { CropBox } from '@/server/crop/crop';
 import { cropBoxToClipPathInset } from '@/server/crop/crop';
 
@@ -13,8 +14,11 @@ type OcrStatus = 'idle' | 'running' | 'complete' | 'error';
 type OcrEngine = 'macOCR' | 'surya' | 'both';
 type OcrTextMode = 'lines' | 'paragraphs';
 type OcrPageText = { lines: string; paragraphs: string };
+type OcrPagesResponse = { dpi?: Coordinates; pages: ObservationPage[] };
+type HorizontalLinesByPage = Record<number, Array<{ height: number; width: number; x: number; y: number }>>;
 
 type OcrProgress = { line: string; currentPage?: number; totalPages?: number; phase?: string };
+const DEFAULT_DPI: Coordinates = { x: 72, y: 72 };
 
 function isProbablyRtl(text: string): boolean {
     return /[\u0590-\u05FF\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/.test(text);
@@ -53,37 +57,83 @@ function scheduleOcrStatusSyncs(params: {
     }
 }
 
-async function fetchOcrTextForPage(
+const normalizeDpi = (dpi: Coordinates | undefined): Coordinates => {
+    if (!dpi) {
+        return DEFAULT_DPI;
+    }
+    const x = Number(dpi.x);
+    const y = Number(dpi.y);
+    if (!Number.isFinite(x) || !Number.isFinite(y) || x <= 0 || y <= 0) {
+        return DEFAULT_DPI;
+    }
+    return { x, y };
+};
+
+const pageToOcrPageText = (params: {
+    dpi: Coordinates;
+    horizontalLines: HorizontalLinesByPage[number];
+    page: ObservationPage;
+}): OcrPageText => {
+    const { dpi, horizontalLines, page } = params;
+    const lines = page.observations.map((o) => o.text).join('\n');
+    try {
+        const reconstructed = reconstructParagraphs(
+            {
+                observations: page.observations,
+                page: { dpiX: dpi.x, dpiY: dpi.y, height: page.height, width: page.width },
+            },
+            { line: { horizontalLines } },
+        );
+        return { lines, paragraphs: reconstructed.text || lines };
+    } catch {
+        return { lines, paragraphs: lines };
+    }
+};
+
+const fetchOcrPages = async (
     jobId: string,
-    pageNumber: number,
     engine: 'ocr' | 'surya',
     signal: AbortSignal,
-): Promise<OcrPageText | null> {
+): Promise<OcrPagesResponse | null> => {
     try {
-        const res = await fetch(`/api/jobs/${encodeURIComponent(jobId)}/${engine}/pages/${pageNumber}`, { signal });
+        const res = await fetch(`/api/jobs/${encodeURIComponent(jobId)}/${engine}/pages`, { signal });
         if (!res.ok) {
             return null;
         }
-        const page = (await res.json()) as ObservationPage;
-        const lines = page.observations.map((o) => o.text).join('\n');
-        try {
-            const reconstructed = reconstructParagraphs({
-                observations: page.observations,
-                page: { dpiX: 72, dpiY: 72, height: page.height, width: page.width },
-            });
-            return { lines, paragraphs: reconstructed.text || lines };
-        } catch {
-            return { lines, paragraphs: lines };
-        }
+        return (await res.json()) as OcrPagesResponse;
     } catch (err: unknown) {
         // AbortError is expected when component unmounts or job changes
         if (err instanceof Error && err.name === 'AbortError') {
             return null;
         }
-        console.warn('[fetchOcrTextForPage.error]', { engine, err, jobId, pageNumber });
+        console.warn('[fetchOcrPages.error]', { engine, err, jobId });
         return null;
     }
-}
+};
+
+const mapPagesToTextByPage = (params: {
+    horizontalLinesByPage: HorizontalLinesByPage;
+    payload: OcrPagesResponse | null;
+}): Record<number, OcrPageText> => {
+    const { horizontalLinesByPage, payload } = params;
+    if (!payload) {
+        return {};
+    }
+
+    const dpi = normalizeDpi(payload.dpi);
+    const textByPage: Record<number, OcrPageText> = {};
+    for (const page of payload.pages) {
+        if (!Number.isInteger(page.page) || page.page <= 0) {
+            continue;
+        }
+        textByPage[page.page] = pageToOcrPageText({
+            dpi,
+            horizontalLines: horizontalLinesByPage[page.page] ?? [],
+            page,
+        });
+    }
+    return textByPage;
+};
 
 function OcrTextCell({
     ready,
@@ -192,10 +242,14 @@ function PageRow({
 }
 
 export function PageOcrTable({
+    analyzeResult,
+    canDetectStructures,
     canLoadMore,
     crop,
+    detectingStructures,
     extractedPages,
     jobId,
+    onDetectStructures,
     onCropPage,
     onLoadMore,
     pages,
@@ -206,12 +260,16 @@ export function PageOcrTable({
     pages: number;
     extractedPages: number;
     crop: CropBox | null;
+    analyzeResult: AnalyzeApiResponse | null;
+    canDetectStructures: boolean;
+    detectingStructures: boolean;
     canLoadMore: boolean;
+    onDetectStructures: () => void;
     onLoadMore: () => void;
     onCropPage: (pageNumber: number) => void;
 }) {
     const clipPath = useMemo(() => (crop ? cropBoxToClipPathInset(crop) : undefined), [crop]);
-    const [selectedEngine, setSelectedEngine] = useState<OcrEngine>('both');
+    const [selectedEngine, setSelectedEngine] = useState<OcrEngine>('macOCR');
     const [ocrTextMode, setOcrTextMode] = useState<OcrTextMode>('lines');
 
     // macOCR state
@@ -219,7 +277,7 @@ export function PageOcrTable({
     const [macOcrError, setMacOcrError] = useState<string | null>(null);
     const [macOcrProgress, setMacOcrProgress] = useState<OcrProgress | null>(null);
     const [macOcrReady, setMacOcrReady] = useState(false);
-    const [macOcrTextByPage, setMacOcrTextByPage] = useState<Record<number, OcrPageText>>({});
+    const [macOcrPayload, setMacOcrPayload] = useState<OcrPagesResponse | null>(null);
     const macOcrEsRef = useRef<EventSource | null>(null);
 
     // Surya state
@@ -227,11 +285,32 @@ export function PageOcrTable({
     const [suryaError, setSuryaError] = useState<string | null>(null);
     const [suryaProgress, setSuryaProgress] = useState<OcrProgress | null>(null);
     const [suryaReady, setSuryaReady] = useState(false);
-    const [suryaTextByPage, setSuryaTextByPage] = useState<Record<number, OcrPageText>>({});
+    const [suryaPayload, setSuryaPayload] = useState<OcrPagesResponse | null>(null);
     const suryaEsRef = useRef<EventSource | null>(null);
 
     const showMacOcr = selectedEngine === 'macOCR' || selectedEngine === 'both';
     const showSurya = selectedEngine === 'surya' || selectedEngine === 'both';
+
+    const horizontalLinesByPage = useMemo<HorizontalLinesByPage>(() => {
+        const byPage: HorizontalLinesByPage = {};
+        for (const page of analyzeResult?.pages ?? []) {
+            if (!Number.isInteger(page.page) || page.page <= 0 || !Array.isArray(page.horizontal_lines)) {
+                continue;
+            }
+            byPage[page.page] = page.horizontal_lines;
+        }
+        return byPage;
+    }, [analyzeResult]);
+
+    const macOcrTextByPage = useMemo(
+        () => mapPagesToTextByPage({ horizontalLinesByPage, payload: macOcrPayload }),
+        [horizontalLinesByPage, macOcrPayload],
+    );
+
+    const suryaTextByPage = useMemo(
+        () => mapPagesToTextByPage({ horizontalLinesByPage, payload: suryaPayload }),
+        [horizontalLinesByPage, suryaPayload],
+    );
 
     const createEventSource = useCallback(
         (
@@ -320,12 +399,12 @@ export function PageOcrTable({
         setMacOcrError(null);
         setMacOcrProgress(null);
         setMacOcrReady(false);
-        setMacOcrTextByPage({});
+        setMacOcrPayload(null);
         setSuryaStatus('idle');
         setSuryaError(null);
         setSuryaProgress(null);
         setSuryaReady(false);
-        setSuryaTextByPage({});
+        setSuryaPayload(null);
 
         macOcrEsRef.current?.close();
         macOcrEsRef.current = null;
@@ -355,6 +434,7 @@ export function PageOcrTable({
         const promises: Promise<void>[] = [];
 
         if (showMacOcr) {
+            setMacOcrPayload(null);
             ensureMacOcrEventSource();
             promises.push(
                 (async () => {
@@ -375,6 +455,7 @@ export function PageOcrTable({
         }
 
         if (showSurya) {
+            setSuryaPayload(null);
             ensureSuryaEventSource();
             promises.push(
                 (async () => {
@@ -397,45 +478,45 @@ export function PageOcrTable({
         await Promise.all(promises);
     };
 
-    // Fetch macOCR text for pages
+    // Fetch macOCR text once for all pages when ready.
     useEffect(() => {
         if (!macOcrReady) {
             return;
         }
+        if (macOcrPayload) {
+            return;
+        }
+
         const controller = new AbortController();
         void (async () => {
-            for (const p of previewPages) {
-                if (controller.signal.aborted || p > extractedPages || macOcrTextByPage[p]) {
-                    continue;
-                }
-                const text = await fetchOcrTextForPage(jobId, p, 'ocr', controller.signal);
-                if (text) {
-                    setMacOcrTextByPage((m) => ({ ...m, [p]: text }));
-                }
+            const payload = await fetchOcrPages(jobId, 'ocr', controller.signal);
+            if (!payload || controller.signal.aborted) {
+                return;
             }
+            setMacOcrPayload(payload);
         })();
         return () => controller.abort();
-    }, [extractedPages, jobId, macOcrReady, macOcrTextByPage, previewPages]);
+    }, [jobId, macOcrPayload, macOcrReady]);
 
-    // Fetch Surya text for pages
+    // Fetch Surya text once for all pages when ready.
     useEffect(() => {
         if (!suryaReady) {
             return;
         }
+        if (suryaPayload) {
+            return;
+        }
+
         const controller = new AbortController();
         void (async () => {
-            for (const p of previewPages) {
-                if (controller.signal.aborted || p > extractedPages || suryaTextByPage[p]) {
-                    continue;
-                }
-                const text = await fetchOcrTextForPage(jobId, p, 'surya', controller.signal);
-                if (text) {
-                    setSuryaTextByPage((m) => ({ ...m, [p]: text }));
-                }
+            const payload = await fetchOcrPages(jobId, 'surya', controller.signal);
+            if (!payload || controller.signal.aborted) {
+                return;
             }
+            setSuryaPayload(payload);
         })();
         return () => controller.abort();
-    }, [extractedPages, jobId, suryaReady, suryaTextByPage, previewPages]);
+    }, [jobId, suryaPayload, suryaReady]);
 
     const formatProgressLabel = (progress: OcrProgress | null, status: OcrStatus, label: string): string | null => {
         if (status !== 'running') {
@@ -484,6 +565,21 @@ export function PageOcrTable({
                         onClick={() => setOcrTextMode((mode) => (mode === 'lines' ? 'paragraphs' : 'lines'))}
                     >
                         {ocrTextMode === 'lines' ? 'Use Paragraph Blocks' : 'Use OCR Lines'}
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={onDetectStructures}
+                        disabled={detectingStructures || !canDetectStructures}
+                    >
+                        {detectingStructures ? (
+                            <>
+                                <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                                Detecting...
+                            </>
+                        ) : (
+                            'Detect Structures'
+                        )}
                     </Button>
                 </div>
             </div>

--- a/src/components/PageOcrTable.tsx
+++ b/src/components/PageOcrTable.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { reconstructParagraphs } from 'kokokor';
 import Image from 'next/image';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
@@ -10,6 +11,8 @@ import { cropBoxToClipPathInset } from '@/server/crop/crop';
 
 type OcrStatus = 'idle' | 'running' | 'complete' | 'error';
 type OcrEngine = 'macOCR' | 'surya' | 'both';
+type OcrTextMode = 'lines' | 'paragraphs';
+type OcrPageText = { lines: string; paragraphs: string };
 
 type OcrProgress = { line: string; currentPage?: number; totalPages?: number; phase?: string };
 
@@ -55,14 +58,23 @@ async function fetchOcrTextForPage(
     pageNumber: number,
     engine: 'ocr' | 'surya',
     signal: AbortSignal,
-): Promise<string | null> {
+): Promise<OcrPageText | null> {
     try {
         const res = await fetch(`/api/jobs/${encodeURIComponent(jobId)}/${engine}/pages/${pageNumber}`, { signal });
         if (!res.ok) {
             return null;
         }
         const page = (await res.json()) as ObservationPage;
-        return page.observations.map((o) => o.text).join('\n');
+        const lines = page.observations.map((o) => o.text).join('\n');
+        try {
+            const reconstructed = reconstructParagraphs({
+                observations: page.observations,
+                page: { dpiX: 72, dpiY: 72, height: page.height, width: page.width },
+            });
+            return { lines, paragraphs: reconstructed.text || lines };
+        } catch {
+            return { lines, paragraphs: lines };
+        }
     } catch (err: unknown) {
         // AbortError is expected when component unmounts or job changes
         if (err instanceof Error && err.name === 'AbortError') {
@@ -200,13 +212,14 @@ export function PageOcrTable({
 }) {
     const clipPath = useMemo(() => (crop ? cropBoxToClipPathInset(crop) : undefined), [crop]);
     const [selectedEngine, setSelectedEngine] = useState<OcrEngine>('both');
+    const [ocrTextMode, setOcrTextMode] = useState<OcrTextMode>('lines');
 
     // macOCR state
     const [macOcrStatus, setMacOcrStatus] = useState<OcrStatus>('idle');
     const [macOcrError, setMacOcrError] = useState<string | null>(null);
     const [macOcrProgress, setMacOcrProgress] = useState<OcrProgress | null>(null);
     const [macOcrReady, setMacOcrReady] = useState(false);
-    const [macOcrTextByPage, setMacOcrTextByPage] = useState<Record<number, string>>({});
+    const [macOcrTextByPage, setMacOcrTextByPage] = useState<Record<number, OcrPageText>>({});
     const macOcrEsRef = useRef<EventSource | null>(null);
 
     // Surya state
@@ -214,7 +227,7 @@ export function PageOcrTable({
     const [suryaError, setSuryaError] = useState<string | null>(null);
     const [suryaProgress, setSuryaProgress] = useState<OcrProgress | null>(null);
     const [suryaReady, setSuryaReady] = useState(false);
-    const [suryaTextByPage, setSuryaTextByPage] = useState<Record<number, string>>({});
+    const [suryaTextByPage, setSuryaTextByPage] = useState<Record<number, OcrPageText>>({});
     const suryaEsRef = useRef<EventSource | null>(null);
 
     const showMacOcr = selectedEngine === 'macOCR' || selectedEngine === 'both';
@@ -465,6 +478,13 @@ export function PageOcrTable({
                     <Button type="button" variant="secondary" onClick={runOcr} disabled={isRunning}>
                         {isRunning ? 'Running OCR…' : 'Run OCR'}
                     </Button>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => setOcrTextMode((mode) => (mode === 'lines' ? 'paragraphs' : 'lines'))}
+                    >
+                        {ocrTextMode === 'lines' ? 'Use Paragraph Blocks' : 'Use OCR Lines'}
+                    </Button>
                 </div>
             </div>
 
@@ -512,9 +532,9 @@ export function PageOcrTable({
                             onCropPage={onCropPage}
                             clipPath={clipPath}
                             macOcrReady={macOcrReady}
-                            macOcrText={macOcrTextByPage[p]}
+                            macOcrText={macOcrTextByPage[p]?.[ocrTextMode]}
                             suryaReady={suryaReady}
-                            suryaText={suryaTextByPage[p]}
+                            suryaText={suryaTextByPage[p]?.[ocrTextMode]}
                             showMacOcr={showMacOcr}
                             showSurya={showSurya}
                         />

--- a/src/lib/skalu.ts
+++ b/src/lib/skalu.ts
@@ -1,0 +1,7 @@
+import type { BoundingBox, Size } from 'kokokor';
+
+export type SkaluPage = Size & { horizontal_lines?: BoundingBox[]; page: number; rectangles?: BoundingBox[] };
+
+export type SkaluApiResponse = { result_data: { pages: SkaluPage[] } };
+
+export type AnalyzeApiResponse = { pages: SkaluPage[] };

--- a/src/lib/uploadthing.ts
+++ b/src/lib/uploadthing.ts
@@ -1,0 +1,4 @@
+import { genUploader } from 'uploadthing/client';
+import type { UploadRouter } from '@/app/api/uploadthing/core';
+
+export const uploadthingClient = genUploader<UploadRouter>({ url: '/api/uploadthing' });

--- a/src/server/jobs/createJobFromPdfBytes.test.ts
+++ b/src/server/jobs/createJobFromPdfBytes.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { createHash } from 'node:crypto';
+import * as fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createJobFromPdfBytes } from '@/server/jobs/createJobFromPdfBytes';
+import { hashIndexPath } from '@/server/jobs/hashIndex';
+import { jobDir, jobPdfPath } from '@/server/jobs/jobPaths';
+import { globalJobStore } from '@/server/jobs/jobStore';
+
+mock.module('@/server/pdf/runner', () => ({ runPdfExtractionJob: mock(async () => {}) }));
+
+const createdJobIds: string[] = [];
+const createdHashes: string[] = [];
+
+afterEach(async () => {
+    for (const id of createdJobIds) {
+        globalJobStore.delete(id);
+        await fsp.rm(jobDir(id), { force: true, recursive: true });
+    }
+    createdJobIds.length = 0;
+
+    for (const hash of createdHashes) {
+        await fsp.rm(hashIndexPath(hash), { force: true });
+    }
+    createdHashes.length = 0;
+});
+
+describe('createJobFromPdfBytes', () => {
+    it('creates a new job, writes pdf, and stores snapshot/hash', async () => {
+        const bytes = new TextEncoder().encode('%PDF-1.7 create helper');
+        const hash = createHash('sha256').update(bytes).digest('hex');
+        createdHashes.push(hash);
+
+        const result = await createJobFromPdfBytes({ bytes });
+        createdJobIds.push(result.jobId);
+
+        expect(result.reused).toBe(false);
+        expect(result.sha256).toBe(hash);
+
+        const stored = globalJobStore.get(result.jobId);
+        expect(stored).toBeTruthy();
+        const onDisk = await fsp.readFile(jobPdfPath(result.jobId));
+        expect(onDisk.length).toBe(bytes.length);
+
+        const snapshotPath = path.join(os.tmpdir(), 'swissawa', result.jobId, 'job.json');
+        const snapshotRaw = await fsp.readFile(snapshotPath, 'utf8');
+        expect(snapshotRaw).toContain(result.jobId);
+    });
+
+    it('reuses existing job for identical bytes', async () => {
+        const bytes = new TextEncoder().encode('%PDF-1.7 duplicate');
+        const hash = createHash('sha256').update(bytes).digest('hex');
+        createdHashes.push(hash);
+
+        const first = await createJobFromPdfBytes({ bytes });
+        createdJobIds.push(first.jobId);
+        const second = await createJobFromPdfBytes({ bytes });
+
+        expect(first.reused).toBe(false);
+        expect(second.reused).toBe(true);
+        expect(second.jobId).toBe(first.jobId);
+        expect(second.sha256).toBe(first.sha256);
+    });
+});

--- a/src/server/jobs/createJobFromPdfBytes.ts
+++ b/src/server/jobs/createJobFromPdfBytes.ts
@@ -1,0 +1,50 @@
+import { createHash, randomUUID } from 'node:crypto';
+import * as fsp from 'node:fs/promises';
+import { readHashIndex, writeHashIndex } from '@/server/jobs/hashIndex';
+import { jobDir, jobImagesDir, jobPdfPath } from '@/server/jobs/jobPaths';
+import { writeJobSnapshot } from '@/server/jobs/jobSnapshot';
+import { globalJobStore } from '@/server/jobs/jobStore';
+import { runPdfExtractionJob } from '@/server/pdf/runner';
+
+export type CreateJobFromPdfBytesParams = { bytes: Uint8Array; sourceUrl?: string };
+
+export type CreateJobFromPdfBytesResult = { jobId: string; reused: boolean; sha256: string };
+
+export async function createJobFromPdfBytes(params: CreateJobFromPdfBytesParams): Promise<CreateJobFromPdfBytesResult> {
+    const sha256 = createHash('sha256').update(params.bytes).digest('hex');
+    const existing = await readHashIndex(sha256);
+    if (existing) {
+        return { jobId: existing.jobId, reused: true, sha256 };
+    }
+
+    const jobId = randomUUID();
+    const dir = jobDir(jobId);
+    const outputDir = jobImagesDir(jobId);
+    const pdfPath = jobPdfPath(jobId);
+
+    await fsp.mkdir(dir, { recursive: true });
+    await fsp.writeFile(pdfPath, params.bytes);
+
+    const job = globalJobStore.create({
+        id: jobId,
+        info: undefined,
+        outputDir,
+        pdfPath,
+        progress: { extractedPages: 0, totalPages: undefined },
+        sourceUrl: params.sourceUrl,
+        status: 'uploaded',
+    });
+    await writeJobSnapshot(job);
+    await writeHashIndex({ createdAtMs: Date.now(), hash: sha256, jobId });
+
+    runPdfExtractionJob({ jobId, store: globalJobStore }).catch((err: unknown) => {
+        const bus = globalJobStore.bus(jobId);
+        globalJobStore.update(jobId, (j) => {
+            j.status = 'error';
+            j.error = err instanceof Error ? err.message : 'Unknown error';
+        });
+        bus?.emit('error', err instanceof Error ? err.message : 'Unknown error');
+    });
+
+    return { jobId, reused: false, sha256 };
+}

--- a/src/server/jobs/jobStore.ts
+++ b/src/server/jobs/jobStore.ts
@@ -9,7 +9,20 @@ export type JobProgress = { extractedPages: number; totalPages?: number };
 
 export type JobOcrStatus = 'idle' | 'running' | 'complete' | 'error';
 
-export type JobOcr = { status: JobOcrStatus; language?: string; error?: string; meta?: OcrMeta; updatedAtMs: number };
+export type JobOcr = {
+    status: JobOcrStatus;
+    language?: string;
+    error?: string;
+    meta?: OcrMeta;
+    updatedAtMs: number;
+    backend?: 'local' | 'github_actions';
+    requestId?: string;
+    runId?: number;
+    artifactName?: string;
+    workflowUrl?: string;
+    startedAtMs?: number;
+    lastCheckedAtMs?: number;
+};
 
 export type Job = {
     id: string;

--- a/src/server/ocr/github/githubActionsClient.test.ts
+++ b/src/server/ocr/github/githubActionsClient.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { GithubActionsClient } from '@/server/ocr/github/githubActionsClient';
+import type { GithubAuthProvider } from '@/server/ocr/github/githubAuth';
+
+class TestAuthProvider implements GithubAuthProvider {
+    async getAccessToken(): Promise<string> {
+        return 'token';
+    }
+}
+
+describe('GithubActionsClient', () => {
+    const auth = new TestAuthProvider();
+
+    beforeEach(() => {
+        mock.restore();
+    });
+
+    it('dispatches workflow and expects 204', async () => {
+        // @ts-expect-error test mock
+        global.fetch = mock(async (_url: string, init?: RequestInit) => {
+            expect(init?.method).toBe('POST');
+            return new Response(null, { status: 204 });
+        });
+
+        const client = new GithubActionsClient({ auth, ref: 'main', repo: 'owner/repo', workflow: 'ocr-remote.yml' });
+        const dispatch = await client.dispatchWorkflow({ request_id: 'abc' });
+        expect(dispatch.requestIdAccepted).toBeTrue();
+    });
+
+    it('retries dispatch without unsupported inputs when workflow rejects them', async () => {
+        let call = 0;
+        // @ts-expect-error test mock
+        global.fetch = mock(async () => {
+            call += 1;
+            if (call === 1) {
+                return Response.json(
+                    {
+                        message: 'Unexpected inputs provided: ["artifact_name", "request_id"]',
+                    },
+                    { status: 422 },
+                );
+            }
+            return new Response(null, { status: 204 });
+        });
+
+        const client = new GithubActionsClient({ auth, ref: 'main', repo: 'owner/repo', workflow: 'ocr-remote.yml' });
+        const dispatch = await client.dispatchWorkflow({
+            artifact_name: 'ocr-results-1',
+            pdf_url: 'https://example.com/input.pdf',
+            request_id: 'abc',
+        });
+        expect(dispatch.requestIdAccepted).toBeFalse();
+        expect(call).toBe(2);
+    });
+
+    it('finds run by request id in run display title', async () => {
+        // @ts-expect-error test mock
+        global.fetch = mock(async () => {
+            return Response.json({
+                workflow_runs: [{ created_at: new Date().toISOString(), display_title: 'remote-ocr:req-123', id: 99 }],
+            });
+        });
+
+        const client = new GithubActionsClient({ auth, ref: 'main', repo: 'owner/repo', workflow: 'ocr-remote.yml' });
+        const run = await client.findRunByRequestId('req-123');
+        expect(run?.id).toBe(99);
+    });
+
+    it('returns null when artifact not found', async () => {
+        // @ts-expect-error test mock
+        global.fetch = mock(async () => Response.json({ artifacts: [] }));
+
+        const client = new GithubActionsClient({ auth, ref: 'main', repo: 'owner/repo', workflow: 'ocr-remote.yml' });
+        const artifact = await client.findArtifactByName(10, 'ocr-results');
+        expect(artifact).toBeNull();
+    });
+
+    it('finds most recent dispatch run since a timestamp', async () => {
+        const nowIso = new Date().toISOString();
+        // @ts-expect-error test mock
+        global.fetch = mock(async () => Response.json({ workflow_runs: [{ created_at: nowIso, id: 77 }] }));
+
+        const client = new GithubActionsClient({ auth, ref: 'main', repo: 'owner/repo', workflow: 'ocr-remote.yml' });
+        const run = await client.findMostRecentDispatchedRunSince(Date.now() - 1000);
+        expect(run?.id).toBe(77);
+    });
+
+    it('falls back artifact lookup to preferred names then first artifact', async () => {
+        // @ts-expect-error test mock
+        global.fetch = mock(async () =>
+            Response.json({
+                artifacts: [
+                    { archive_download_url: 'https://a.example', expired: false, id: 1, name: 'other' },
+                    { archive_download_url: 'https://b.example', expired: false, id: 2, name: 'ocr-results' },
+                ],
+            }),
+        );
+
+        const client = new GithubActionsClient({ auth, ref: 'main', repo: 'owner/repo', workflow: 'ocr-remote.yml' });
+        const artifact = await client.findArtifactForRun(10, ['custom-name', 'ocr-results']);
+        expect(artifact?.name).toBe('ocr-results');
+    });
+
+    it('throws on timeout while waiting for completion', async () => {
+        // @ts-expect-error test mock
+        global.fetch = mock(async () => {
+            return Response.json({
+                conclusion: null,
+                created_at: new Date().toISOString(),
+                html_url: 'https://example.com',
+                id: 1,
+                status: 'in_progress',
+            });
+        });
+
+        const client = new GithubActionsClient({ auth, ref: 'main', repo: 'owner/repo', workflow: 'ocr-remote.yml' });
+        await expect(client.waitForRunCompletion(1, 1, 1)).rejects.toThrow('Timed out');
+    });
+});

--- a/src/server/ocr/github/githubActionsClient.ts
+++ b/src/server/ocr/github/githubActionsClient.ts
@@ -1,0 +1,215 @@
+import type { GithubAuthProvider } from '@/server/ocr/github/githubAuth';
+
+type WorkflowRun = {
+    id: number;
+    html_url: string;
+    status: 'queued' | 'in_progress' | 'completed' | string;
+    conclusion: string | null;
+    name?: string;
+    display_title?: string;
+    created_at: string;
+};
+
+type Artifact = { id: number; name: string; archive_download_url: string; expired: boolean };
+type DispatchResult = { dispatchedAtMs: number; requestIdAccepted: boolean };
+
+function parseRepo(repo: string): { owner: string; repo: string } {
+    const [owner, name] = repo.split('/');
+    if (!owner || !name) {
+        throw new Error('SWISSAWA_GH_OCR_REPO must be "owner/repo"');
+    }
+    return { owner, repo: name };
+}
+
+async function githubRequest(
+    auth: GithubAuthProvider,
+    path: string,
+    init?: RequestInit,
+    expectStatus?: number | number[],
+): Promise<Response> {
+    const token = await auth.getAccessToken();
+    const response = await fetch(`https://api.github.com${path}`, {
+        ...init,
+        headers: {
+            Accept: 'application/vnd.github+json',
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+            'X-GitHub-Api-Version': '2022-11-28',
+            ...(init?.headers ?? {}),
+        },
+    });
+    if (!expectStatus) {
+        return response;
+    }
+    const expected = Array.isArray(expectStatus) ? expectStatus : [expectStatus];
+    if (!expected.includes(response.status)) {
+        const body = await response.text().catch(() => '');
+        throw new Error(`GitHub API ${path} failed (${response.status}): ${body}`);
+    }
+    return response;
+}
+
+async function githubAbsoluteRequest(auth: GithubAuthProvider, url: string, init?: RequestInit): Promise<Response> {
+    const token = await auth.getAccessToken();
+    return await fetch(url, {
+        ...init,
+        headers: {
+            Accept: 'application/vnd.github+json',
+            Authorization: `Bearer ${token}`,
+            'X-GitHub-Api-Version': '2022-11-28',
+            ...(init?.headers ?? {}),
+        },
+    });
+}
+
+export type GithubActionsClientOptions = { auth: GithubAuthProvider; repo: string; workflow: string; ref: string };
+
+export class GithubActionsClient {
+    private readonly auth: GithubAuthProvider;
+    private readonly owner: string;
+    private readonly repo: string;
+    private readonly workflow: string;
+    private readonly ref: string;
+
+    constructor(options: GithubActionsClientOptions) {
+        this.auth = options.auth;
+        const parsed = parseRepo(options.repo);
+        this.owner = parsed.owner;
+        this.repo = parsed.repo;
+        this.workflow = options.workflow;
+        this.ref = options.ref;
+    }
+
+    workflowRunUrl(runId: number): string {
+        return `https://github.com/${this.owner}/${this.repo}/actions/runs/${runId}`;
+    }
+
+    async dispatchWorkflow(inputs: Record<string, string>): Promise<DispatchResult> {
+        const path = `/repos/${this.owner}/${this.repo}/actions/workflows/${encodeURIComponent(this.workflow)}/dispatches`;
+        const dispatchedAtMs = Date.now();
+        try {
+            await githubRequest(
+                this.auth,
+                path,
+                { body: JSON.stringify({ inputs, ref: this.ref }), method: 'POST' },
+                204,
+            );
+            return { dispatchedAtMs, requestIdAccepted: true };
+        } catch (err) {
+            // Backward-compatibility with older workflows that don't define request_id/artifact_name inputs.
+            if (!(err instanceof Error) || !err.message.includes('Unexpected inputs provided')) {
+                throw err;
+            }
+            const legacyInputs = { ...inputs };
+            delete legacyInputs.request_id;
+            delete legacyInputs.artifact_name;
+            await githubRequest(
+                this.auth,
+                path,
+                { body: JSON.stringify({ inputs: legacyInputs, ref: this.ref }), method: 'POST' },
+                204,
+            );
+            return { dispatchedAtMs, requestIdAccepted: false };
+        }
+    }
+
+    async findRunByRequestId(requestId: string): Promise<WorkflowRun | null> {
+        const response = await githubRequest(
+            this.auth,
+            `/repos/${this.owner}/${this.repo}/actions/workflows/${encodeURIComponent(this.workflow)}/runs?event=workflow_dispatch&per_page=30`,
+            undefined,
+            200,
+        );
+        const data = (await response.json()) as { workflow_runs?: WorkflowRun[] };
+        const runs = data.workflow_runs ?? [];
+        for (const run of runs) {
+            const title = `${run.display_title ?? ''} ${run.name ?? ''}`;
+            if (title.includes(requestId)) {
+                return run;
+            }
+        }
+        return null;
+    }
+
+    async findMostRecentDispatchedRunSince(sinceMs: number): Promise<WorkflowRun | null> {
+        const response = await githubRequest(
+            this.auth,
+            `/repos/${this.owner}/${this.repo}/actions/workflows/${encodeURIComponent(this.workflow)}/runs?event=workflow_dispatch&per_page=30`,
+            undefined,
+            200,
+        );
+        const data = (await response.json()) as { workflow_runs?: WorkflowRun[] };
+        const runs = data.workflow_runs ?? [];
+        const threshold = sinceMs - 15_000;
+        for (const run of runs) {
+            const createdAtMs = Date.parse(run.created_at);
+            if (Number.isFinite(createdAtMs) && createdAtMs >= threshold) {
+                return run;
+            }
+        }
+        return null;
+    }
+
+    async getRun(runId: number): Promise<WorkflowRun> {
+        const response = await githubRequest(
+            this.auth,
+            `/repos/${this.owner}/${this.repo}/actions/runs/${runId}`,
+            undefined,
+            200,
+        );
+        return (await response.json()) as WorkflowRun;
+    }
+
+    async waitForRunCompletion(runId: number, timeoutMs: number, pollIntervalMs: number): Promise<WorkflowRun> {
+        const startedAt = Date.now();
+        while (true) {
+            const run = await this.getRun(runId);
+            if (run.status === 'completed') {
+                return run;
+            }
+            if (Date.now() - startedAt > timeoutMs) {
+                throw new Error('Timed out waiting for remote workflow completion');
+            }
+            await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+        }
+    }
+
+    async findArtifactByName(runId: number, artifactName: string): Promise<Artifact | null> {
+        const response = await githubRequest(
+            this.auth,
+            `/repos/${this.owner}/${this.repo}/actions/runs/${runId}/artifacts`,
+            undefined,
+            200,
+        );
+        const data = (await response.json()) as { artifacts?: Artifact[] };
+        const artifacts = data.artifacts ?? [];
+        return artifacts.find((a) => a.name === artifactName && !a.expired) ?? null;
+    }
+
+    async findArtifactForRun(runId: number, preferredNames: string[]): Promise<Artifact | null> {
+        const response = await githubRequest(
+            this.auth,
+            `/repos/${this.owner}/${this.repo}/actions/runs/${runId}/artifacts`,
+            undefined,
+            200,
+        );
+        const data = (await response.json()) as { artifacts?: Artifact[] };
+        const artifacts = (data.artifacts ?? []).filter((a) => !a.expired);
+        for (const name of preferredNames) {
+            const match = artifacts.find((a) => a.name === name);
+            if (match) {
+                return match;
+            }
+        }
+        return artifacts[0] ?? null;
+    }
+
+    async downloadArtifactZip(artifact: Artifact): Promise<ArrayBuffer> {
+        const response = await githubAbsoluteRequest(this.auth, artifact.archive_download_url);
+        if (!response.ok) {
+            const body = await response.text().catch(() => '');
+            throw new Error(`Failed to download artifact (${response.status}): ${body}`);
+        }
+        return await response.arrayBuffer();
+    }
+}

--- a/src/server/ocr/github/githubAuth.ts
+++ b/src/server/ocr/github/githubAuth.ts
@@ -1,0 +1,13 @@
+export interface GithubAuthProvider {
+    getAccessToken(): Promise<string>;
+}
+
+export class PatAuthProvider implements GithubAuthProvider {
+    async getAccessToken(): Promise<string> {
+        const token = process.env.SWISSAWA_GH_PAT;
+        if (!token) {
+            throw new Error('Missing SWISSAWA_GH_PAT');
+        }
+        return token;
+    }
+}

--- a/src/server/ocr/providers/githubActionsMacOcrProvider.ts
+++ b/src/server/ocr/providers/githubActionsMacOcrProvider.ts
@@ -1,0 +1,255 @@
+import { randomUUID } from 'node:crypto';
+import * as fsp from 'node:fs/promises';
+import path from 'node:path';
+import AdmZip from 'adm-zip';
+import { UTApi } from 'uploadthing/server';
+import { isFullCropBox, normalizeCropBox } from '@/lib/cropConvert';
+import type { MacOCR } from '@/lib/macOcr';
+import { readCropBox } from '@/server/crop/cropStore';
+import { writeJobSnapshot } from '@/server/jobs/jobSnapshot';
+import type { JobOcr, JobStore } from '@/server/jobs/jobStore';
+import { GithubActionsClient } from '@/server/ocr/github/githubActionsClient';
+import { PatAuthProvider } from '@/server/ocr/github/githubAuth';
+import { emitOcrComplete, emitOcrError, emitOcrProgress } from '@/server/ocr/ocrEventBus';
+import { jobOcrDir, jobOcrInputPdfPath, jobOcrJsonPath } from '@/server/ocr/ocrPaths';
+import type { MacOcrProvider, StartMacOcrParams } from '@/server/ocr/providers/macOcrProvider';
+import { buildOcrMeta, splitMacOcrToPages, writeOcrMeta } from '@/server/ocr/splitMacOcr';
+import { cropPdfBytes } from '@/server/pdf/cropPdf';
+
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000;
+
+const runningByJobId = new Map<string, Promise<void>>();
+
+function readNumberEnv(name: string, fallback: number): number {
+    const raw = process.env[name];
+    if (!raw) {
+        return fallback;
+    }
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isFinite(n) || n <= 0) {
+        return fallback;
+    }
+    return n;
+}
+
+function requiredEnv(name: string): string {
+    const value = process.env[name];
+    if (!value) {
+        throw new Error(`Missing ${name}`);
+    }
+    return value;
+}
+
+function parseMacOcrJson(raw: string): MacOCR {
+    const json = JSON.parse(raw) as unknown;
+    if (!json || typeof json !== 'object') {
+        throw new Error('Invalid macOCR output JSON');
+    }
+    return json as MacOCR;
+}
+
+async function getOcrInputPdfBytes(jobId: string, store: JobStore): Promise<Uint8Array> {
+    const job = store.get(jobId);
+    if (!job) {
+        throw new Error(`Job not found: ${jobId}`);
+    }
+    const original = await fsp.readFile(job.pdfPath);
+    const crop = job.crop ?? (await readCropBox(jobId));
+    if (!crop) {
+        return original;
+    }
+    const normalized = normalizeCropBox(crop);
+    if (isFullCropBox(normalized)) {
+        return original;
+    }
+    return await cropPdfBytes(original, normalized, { shrinkPage: true });
+}
+
+async function resolveRemotePdfUrl(
+    params: StartMacOcrParams,
+    job: NonNullable<ReturnType<JobStore['get']>>,
+): Promise<string> {
+    const sourceUrl = job.sourceUrl;
+    const crop = job.crop ?? (await readCropBox(params.jobId));
+    if (sourceUrl && (!crop || isFullCropBox(normalizeCropBox(crop)))) {
+        emitOcrProgress(params.jobId, { line: 'Using original remote PDF URL for OCR input…' });
+        return sourceUrl;
+    }
+
+    emitOcrProgress(params.jobId, { line: 'Preparing cropped PDF for remote OCR…' });
+    const inputPdfBytes = await getOcrInputPdfBytes(params.jobId, params.store);
+    await fsp.writeFile(jobOcrInputPdfPath(params.jobId), inputPdfBytes);
+
+    const utapi = new UTApi();
+    const uploadBytes = new Uint8Array(inputPdfBytes);
+    const uploadFile = new File([uploadBytes], `${params.jobId}-input.pdf`, { type: 'application/pdf' });
+    emitOcrProgress(params.jobId, { line: 'Uploading OCR input PDF to UploadThing…' });
+    const uploadResult = await utapi.uploadFiles(uploadFile);
+    if (!uploadResult?.data?.key) {
+        throw new Error('Failed to upload OCR input PDF to UploadThing');
+    }
+    const { ufsUrl } = await utapi.generateSignedURL(uploadResult.data.key, { expiresIn: '15 minutes' });
+    return ufsUrl;
+}
+
+async function updateOcrStatus(store: JobStore, jobId: string, updater: (current: JobOcr) => void): Promise<void> {
+    const updated = store.update(jobId, (j) => {
+        const current: JobOcr = j.ocr ?? { status: 'idle', updatedAtMs: Date.now() };
+        const next: JobOcr = { ...current, updatedAtMs: Date.now() };
+        updater(next);
+        j.ocr = next;
+    });
+    await writeJobSnapshot(updated);
+}
+
+function getRemoteConfig(): { pollIntervalMs: number; ref: string; repo: string; timeoutMs: number; workflow: string } {
+    return {
+        pollIntervalMs: readNumberEnv('SWISSAWA_GH_OCR_POLL_INTERVAL_MS', DEFAULT_POLL_INTERVAL_MS),
+        ref: process.env.SWISSAWA_GH_OCR_REF ?? 'main',
+        repo: requiredEnv('SWISSAWA_GH_OCR_REPO'),
+        timeoutMs: readNumberEnv('SWISSAWA_GH_OCR_TIMEOUT_MS', DEFAULT_TIMEOUT_MS),
+        workflow: process.env.SWISSAWA_GH_OCR_WORKFLOW ?? 'ocr-remote.yml',
+    };
+}
+
+function readOutputJsonFromZip(zipBuffer: ArrayBuffer): string {
+    const zip = new AdmZip(Buffer.from(zipBuffer));
+    const entries = zip.getEntries().filter((entry) => !entry.isDirectory);
+    const outputEntry = entries.find((entry) => path.basename(entry.entryName) === 'output.json');
+    if (outputEntry) {
+        return outputEntry.getData().toString('utf8');
+    }
+    const anyJson = entries.find((entry) => entry.entryName.endsWith('.json'));
+    if (anyJson) {
+        return anyJson.getData().toString('utf8');
+    }
+    throw new Error('Remote OCR artifact does not contain a JSON output file');
+}
+
+export class GithubActionsMacOcrProvider implements MacOcrProvider {
+    async start(params: StartMacOcrParams): Promise<void> {
+        const existing = runningByJobId.get(params.jobId);
+        if (existing) {
+            return existing;
+        }
+
+        const promise = (async () => {
+            const job = params.store.get(params.jobId);
+            if (!job) {
+                throw new Error(`Job not found: ${params.jobId}`);
+            }
+
+            const language = params.language ?? 'ar-SA';
+            const splitPages = params.splitPages ?? true;
+            const requestId = randomUUID();
+            const artifactName = `ocr-results-${params.jobId}-${requestId.slice(0, 8)}`;
+            const config = getRemoteConfig();
+            const ocrDir = jobOcrDir(params.jobId);
+
+            await updateOcrStatus(params.store, params.jobId, (ocr) => {
+                ocr.status = 'running';
+                ocr.language = language;
+                ocr.backend = 'github_actions';
+                ocr.requestId = requestId;
+                ocr.artifactName = artifactName;
+                ocr.startedAtMs = Date.now();
+                delete ocr.error;
+            });
+
+            await fsp.mkdir(ocrDir, { recursive: true });
+            const pdfUrl = await resolveRemotePdfUrl(params, job);
+
+            const auth = new PatAuthProvider();
+            const client = new GithubActionsClient({
+                auth,
+                ref: config.ref,
+                repo: config.repo,
+                workflow: config.workflow,
+            });
+
+            emitOcrProgress(params.jobId, { line: 'Dispatching remote OCR workflow…' });
+            const dispatch = await client.dispatchWorkflow({
+                artifact_name: artifactName,
+                languages: language,
+                output_format: 'json',
+                pdf_url: pdfUrl,
+                request_id: requestId,
+            });
+            if (!dispatch.requestIdAccepted) {
+                emitOcrProgress(params.jobId, { line: 'Workflow does not support request_id; using latest-run correlation…' });
+            }
+
+            const runSearchStartedAt = Date.now();
+            let runId: number | null = null;
+            while (!runId) {
+                const run = dispatch.requestIdAccepted
+                    ? await client.findRunByRequestId(requestId)
+                    : await client.findMostRecentDispatchedRunSince(dispatch.dispatchedAtMs);
+                if (run) {
+                    runId = run.id;
+                    await updateOcrStatus(params.store, params.jobId, (ocr) => {
+                        ocr.runId = run.id;
+                        ocr.workflowUrl = run.html_url || client.workflowRunUrl(run.id);
+                        ocr.lastCheckedAtMs = Date.now();
+                    });
+                    break;
+                }
+                if (Date.now() - runSearchStartedAt > config.timeoutMs) {
+                    throw new Error('Timed out while waiting for workflow run to appear');
+                }
+                emitOcrProgress(params.jobId, { line: 'Waiting for remote workflow run to start…' });
+                await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));
+            }
+
+            emitOcrProgress(params.jobId, { line: 'Remote OCR workflow running…' });
+            const finalRun = await client.waitForRunCompletion(runId, config.timeoutMs, config.pollIntervalMs);
+            await updateOcrStatus(params.store, params.jobId, (ocr) => {
+                ocr.lastCheckedAtMs = Date.now();
+                ocr.workflowUrl = finalRun.html_url || client.workflowRunUrl(finalRun.id);
+            });
+
+            if (finalRun.conclusion !== 'success') {
+                throw new Error(`Remote OCR workflow failed (${finalRun.conclusion ?? 'unknown'})`);
+            }
+
+            emitOcrProgress(params.jobId, { line: 'Downloading OCR artifact…' });
+            const artifact = await client.findArtifactForRun(runId, [artifactName, 'ocr-results']);
+            if (!artifact) {
+                throw new Error('Artifact not found for remote OCR run');
+            }
+            const zipBuffer = await client.downloadArtifactZip(artifact);
+            const rawJson = readOutputJsonFromZip(zipBuffer);
+            const ocr = parseMacOcrJson(rawJson);
+
+            await fsp.writeFile(jobOcrJsonPath(params.jobId), rawJson, 'utf8');
+            const meta = buildOcrMeta(ocr, language);
+            await writeOcrMeta(ocrDir, meta);
+            if (splitPages) {
+                await splitMacOcrToPages({ language, ocr, outDir: ocrDir });
+            }
+
+            await updateOcrStatus(params.store, params.jobId, (s) => {
+                s.status = 'complete';
+                s.meta = meta;
+                s.lastCheckedAtMs = Date.now();
+            });
+            emitOcrComplete(params.jobId);
+        })()
+            .catch(async (err: unknown) => {
+                await updateOcrStatus(params.store, params.jobId, (s) => {
+                    s.status = 'error';
+                    s.error = err instanceof Error ? err.message : 'OCR failed';
+                    s.lastCheckedAtMs = Date.now();
+                });
+                emitOcrError(params.jobId, err instanceof Error ? err.message : 'OCR failed');
+                throw err;
+            })
+            .finally(() => {
+                runningByJobId.delete(params.jobId);
+            });
+
+        runningByJobId.set(params.jobId, promise);
+        return promise;
+    }
+}

--- a/src/server/ocr/providers/index.ts
+++ b/src/server/ocr/providers/index.ts
@@ -1,0 +1,11 @@
+import { GithubActionsMacOcrProvider } from '@/server/ocr/providers/githubActionsMacOcrProvider';
+import { LocalMacOcrProvider } from '@/server/ocr/providers/localMacOcrProvider';
+import type { MacOcrProvider } from '@/server/ocr/providers/macOcrProvider';
+
+export function getMacOcrProvider(): MacOcrProvider {
+    const backend = process.env.SWISSAWA_MAC_OCR_BACKEND ?? 'local';
+    if (backend === 'github_actions') {
+        return new GithubActionsMacOcrProvider();
+    }
+    return new LocalMacOcrProvider();
+}

--- a/src/server/ocr/providers/localMacOcrProvider.ts
+++ b/src/server/ocr/providers/localMacOcrProvider.ts
@@ -1,0 +1,8 @@
+import type { MacOcrProvider, StartMacOcrParams } from '@/server/ocr/providers/macOcrProvider';
+import { runMacOcr } from '@/server/ocr/runMacOcr';
+
+export class LocalMacOcrProvider implements MacOcrProvider {
+    async start(params: StartMacOcrParams): Promise<void> {
+        await runMacOcr(params);
+    }
+}

--- a/src/server/ocr/providers/macOcrProvider.ts
+++ b/src/server/ocr/providers/macOcrProvider.ts
@@ -1,0 +1,7 @@
+import type { JobStore } from '@/server/jobs/jobStore';
+
+export type StartMacOcrParams = { jobId: string; store: JobStore; language?: string; splitPages?: boolean };
+
+export interface MacOcrProvider {
+    start(params: StartMacOcrParams): Promise<void>;
+}


### PR DESCRIPTION
# ADR 0001: Remote OCR Auth Strategy

- Date: February 11, 2026
- Status: Accepted

## Context

`swissawa` needs to offload macOCR processing to a remote GitHub Actions workflow. We need to ship quickly while keeping a secure long-term path.

## Decision

Use a PAT-first authentication strategy for remote workflow dispatch and artifact retrieval in the initial release.

- Local default remains fully local (`SWISSAWA_MAC_OCR_BACKEND=local`).
- Deployed mode can use GitHub Actions backend (`SWISSAWA_MAC_OCR_BACKEND=github_actions`) with `SWISSAWA_GH_PAT`.
- OAuth/App-like token handling is abstracted behind `GithubAuthProvider` so migration to GitHub App is a drop-in change.

## Rationale

- Fastest path to production.
- Minimal setup and environment surface area.
- Keeps architecture migration-ready by separating auth concerns from workflow orchestration.

## Consequences

- PAT is long-lived and tied to a user/service account.
- Rotation and scope hygiene must be managed in deployment ops.

## Migration Checklist to GitHub App

1. Implement `GitHubAppAuthProvider` in `src/server/ocr/github/githubAuth.ts` (or adjacent file).
2. Add GitHub App env vars:
   - `SWISSAWA_GH_APP_ID`
   - `SWISSAWA_GH_APP_PRIVATE_KEY`
   - `SWISSAWA_GH_APP_INSTALLATION_ID`
3. Replace provider wiring used by remote OCR provider from `PatAuthProvider` to `GitHubAppAuthProvider`.
4. Keep all `GithubActionsClient` and OCR provider logic unchanged.
5. Remove PAT secret from deployment after cutover.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New OCR file download endpoint for full OCR JSON.
  * UploadThing integration with direct and ingest upload endpoints.
  * Remote OCR via GitHub Actions (PAT-first) and a UI upload-mode switch to choose upload flow.
  * Structure-detection API and UI controls; switchable OCR text display modes (lines vs. paragraphs).

* **Documentation**
  * Expanded README with detailed Remote OCR setup, PAT and GitHub App guidance, and deployment notes.

* **Chores**
  * Bumped Bun engine minimum to 1.3.9 and added/upload-related dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->